### PR TITLE
feat: Implement TLS config with per-listener/target custom root CA bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github/
 target/
 tests/
+!tests/scripts/
 *.yaml
 *.yml
 *.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git/
+.github/
+target/
+tests/
+*.yaml
+*.yml
+*.md
+*.snap
+mutants.out/
+mutants.out.old/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ config*.yaml
 
 values*.yaml
 TODO*
+
+*.pem
+
+mutants.out/
+mutants.out.old/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ values*.yaml
 TODO*
 
 *.pem
+*.key
+*.crt
+*.req
 
 mutants.out/
 mutants.out.old/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -800,9 +800,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linked-hash-map"
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1512,9 +1512,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,12 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -205,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -554,14 +557,14 @@ dependencies = [
 
 [[package]]
 name = "http-dragonfly"
-version = "0.2.10"
+version = "0.3.0"
 dependencies = [
  "clap",
  "futures-util",
  "http-body-util",
  "humantime-serde",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "insta",
  "jaq-interpret",
@@ -569,6 +572,8 @@ dependencies = [
  "once_cell",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -642,10 +647,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -696,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -792,9 +799,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "linked-hash-map"
@@ -1233,10 +1240,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1321,18 +1342,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1341,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -1401,6 +1422,12 @@ name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1938,6 +1965,15 @@ checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1147,9 +1148,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1185,7 +1186,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1525,23 +1526,26 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1607,9 +1611,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2008,12 +2012,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2022,7 +2047,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2031,22 +2056,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2055,21 +2065,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2079,21 +2083,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2109,21 +2101,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2133,37 +2113,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,11 @@ jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
 once_cell = "1.19.0"
 regex = "1.10.6"
-rustls = { version = "0.23.12", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "0.23.12", default-features = false, features = [
+    "ring",
+    "std",
+    "tls12",
+] }
 rustls-pemfile = "2.1.3"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
@@ -45,7 +49,7 @@ shellexpand = { version = "3.1.0", default-features = false, features = [
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 thiserror = "1.0.63"
-tokio = { version = "1.39.2", features = [
+tokio = { version = "1.39.3", features = [
     "macros",
     "signal",
     "tracing",
@@ -62,4 +66,8 @@ insta = { version = "1.39.0", features = [
     "redactions",
     "filters",
 ] }
-reqwest = "0.12.5"
+reqwest = "0.12.7"
+tokio-rustls = { version = "0.26.0", default-features = false, features = [
+    "ring",
+    "tls12",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,23 @@ keywords = ["http", "splitter", "relay", "router"]
 license = "MIT OR Apache-2.0"
 name = "http-dragonfly"
 repository = "https://github.com/alex-karpenko/http-dragonfly"
-version = "0.2.10"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.14", features = ["derive"] }
+clap = { version = "4.5.16", features = ["derive"] }
 futures-util = "0.3.30"
 http-body-util = "0.1.2"
 humantime-serde = "1.1.1"
 hyper = { version = "1.4.1", features = ["http1"] }
-hyper-tls = "0.6.0"
+hyper-rustls = { version = "0.27.2", default-features = false, features = [
+    "http1",
+    "ring",
+    "rustls-native-certs",
+    "tls12",
+    "webpki-roots",
+] }
 hyper-util = { version = "0.1.7", features = [
     "server",
     "client",
@@ -28,8 +34,10 @@ jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
 once_cell = "1.19.0"
 regex = "1.10.6"
-serde = { version = "1.0.205", features = ["derive"] }
-serde_json = "1.0.122"
+rustls = { version = "0.23.12", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pemfile = "2.1.3"
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.125"
 serde_yaml = "0.9.34"
 shellexpand = { version = "3.1.0", default-features = false, features = [
     "base-0",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ RUN cargo build --release
 RUN strip target/release/http-dragonfly
 
 # Runtime stage
-FROM debian:12-slim
-
-RUN apt update && apt install -y ca-certificates && apt clean
+FROM gcr.io/distroless/cc-debian12
 
 USER nobody
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -428,8 +428,9 @@ Target config includes the following parameters:
 
 - `id`: unique (among the listener's targets) target name/ID, default is `TARGET-<url>`
 - `url`: full URL of the target
-- `tls`: the same as [listener TLS config](#listener-tls), by default listeners' config is user, but if it's defined on
-  target level it overrides listeners' values
+- `tls`: the same as [listener TLS config](#listener-tls), by default listeners' config is used, but if it's defined on
+  the target level, it overrides listeners' values. Be careful: if you disabled TLS verification of listener but need to use
+  custom root CA certificate on target, then you have to enable TLS verification on target.
 - `headers`: target's headers transformations, [like request's config](#listener-headers), empty by default
 - `body`: create new body if defined, or pass original body by default
 - `timeout`: time to wait for response from the target, [like listener's config](#listener-timeout), default is `60s`

--- a/README.md
+++ b/README.md
@@ -281,6 +281,37 @@ Each listener accepts connections on its own IP and port.
 If you have more than one listener in the config,
 you have to specify this parameter at least for all non-default listeners.
 
+#### Listener: `tls`
+
+Format: object with two fields: `verify` and `ca`.
+
+Default:
+```yaml
+  tls:
+    verify: yes
+    ca: null
+```
+
+This object specifies how to treat outgoing TLS connections. `verify` field sets server certificate verification mode, possible values:
+- `yes`: verify server certificate (validity and hostname), default;
+- `no`: skip TLS verification, generally this is a dangerous setup.
+
+`ca` field is used to specify path to the file with custom root CA certificates bundle in PEM format to use instead of the system one.
+
+So the default TLS verification behavior is:
+- skip TLS verification if it's disabled in listener or target config (`tls.verify: no`);
+- else, use custom root CA certificate bundle (file in PEM format) if it's defined in listener or target config
+  (`tls.verify: yes` and `tls.ca` has a path to the file);
+- else, use OS native certificates bundle if it's present;
+- else, use Mozilla root CA bundle.
+
+Example:
+```yaml
+tls:
+  verify: yes
+  ca: /custom_ca.pem
+```
+
 #### Listener: `timeout`
 
 Format: human readable time interval, like `5s`, `1m30s`, etc.
@@ -397,6 +428,8 @@ Target config includes the following parameters:
 
 - `id`: unique (among the listener's targets) target name/ID, default is `TARGET-<url>`
 - `url`: full URL of the target
+- `tls`: the same as [listener TLS config](#listener-tls), by default listeners' config is user, but if it's defined on
+  target level it overrides listeners' values
 - `headers`: target's headers transformations, [like request's config](#listener-headers), empty by default
 - `body`: create new body if defined, or pass original body by default
 - `timeout`: time to wait for response from the target, [like listener's config](#listener-timeout), default is `60s`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Actually use cases are restricted by your fantasy only :)
 
 The easiest way to run `http-dragonfly` is to use [Docker image](#docker-image).
 If you use Kubernetes to run workload, you can use [Helm chart](#helm-chart) to configure and deploy `http-dragonfly`.
-The third way to run `http-dragonfly` is to [build native Rust binary](#build-your-own-binary) using Cargo utility and run it.
+The third way to run `http-dragonfly` is to [build native Rust binary](#build-your-own-binary) using Cargo utility and
+run it.
 
 Anyway, to run `http-dragonfly` we need a [configuration file](#concepts-and-configuration) with listeners, targets,
 transformations and response strategy configured.
@@ -90,7 +91,8 @@ Options:
 ```
 
 The only mandatory parameter is a path to configuration file.
-Detailed explanation of all possible configuration options is in the dedicated [Concepts and Configuration](#concepts-and-configuration) section.
+Detailed explanation of all possible configuration options is in the
+dedicated [Concepts and Configuration](#concepts-and-configuration) section.
 Just for test purpose, there is
 an [example minimal config](config.yaml) file to listen on default 8080 port and forward requests
 to <http://www.google.com/>.
@@ -200,7 +202,7 @@ Just a few examples of how to use contexts:
 There are four contexts depending on the query stage:
 
 | Context type | Variables                                    | Description                                                                                                                           |
-| ------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Application  | CTX_APPLICATION_NAME                         | Name of this app, `http-dragonfly`                                                                                                    |
 |              | CTX_APPLICATION_VERSION                      | Version of the app                                                                                                                    |
 |              | OS environment variables                     | All OS environment variables which names satisfy restriction mask from the command line (default mask is `^HTTP_ENV_[a-zA-Z0-9_]+$]`) |
@@ -286,26 +288,31 @@ you have to specify this parameter at least for all non-default listeners.
 Format: object with two fields: `verify` and `ca`.
 
 Default:
+
 ```yaml
   tls:
     verify: yes
     ca: null
 ```
 
-This object specifies how to treat outgoing TLS connections. `verify` field sets server certificate verification mode, possible values:
+This object specifies how to process outgoing TLS connections.
+`verify` field sets server certificate verification mode, possible values:
 - `yes`: verify server certificate (validity and hostname), default;
 - `no`: skip TLS verification, generally this is a dangerous setup.
 
-`ca` field is used to specify path to the file with custom root CA certificates bundle in PEM format to use instead of the system one.
+`ca` field is used to specify a path to the file with custom root CA certificates bundle in PEM format to use instead of
+the system one.
 
 So the default TLS verification behavior is:
+
 - skip TLS verification if it's disabled in listener or target config (`tls.verify: no`);
-- else, use custom root CA certificate bundle (file in PEM format) if it's defined in listener or target config
+- else, use a custom root CA certificate bundle (file in PEM format) if it's defined in listener or target config
   (`tls.verify: yes` and `tls.ca` has a path to the file);
 - else, use OS native certificates bundle if it's present;
 - else, use Mozilla root CA bundle.
 
 Example:
+
 ```yaml
 tls:
   verify: yes
@@ -359,7 +366,7 @@ Generally, all strategies can be divided into four groups by prefixes:
   response.
 
 | Strategy name         | How it works                                                                                                                                                                                                                                                                                                                  |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | always_override       | Query all allowed targets (see explanation of allowed targets below the table) but return response defined in `response.override` section (see below)                                                                                                                                                                         |
 | always_target_id      | Query all allowed targets but return response from one specific target regardless of it's status                                                                                                                                                                                                                              |
 | ok_then_failed        | Query all allowed targets, if at least on response is successful - return any successful one, if all responses are failed - return any failed response                                                                                                                                                                        |
@@ -429,7 +436,8 @@ Target config includes the following parameters:
 - `id`: unique (among the listener's targets) target name/ID, default is `TARGET-<url>`
 - `url`: full URL of the target
 - `tls`: the same as [listener TLS config](#listener-tls), by default listeners' config is used, but if it's defined on
-  the target level, it overrides listeners' values. Be careful: if you disabled TLS verification of listener but need to use
+  the target level, it overrides listeners' values.
+  Be careful: if you disabled TLS verification of listener but need to use
   custom root CA certificate on target, then you have to enable TLS verification on target.
 - `headers`: target's headers transformations, [like request's config](#listener-headers), empty by default
 - `body`: create new body if defined, or pass original body by default

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::{env, error::Error, process::Command};
+
+const CERTIFICATES_GENERATOR_SCRIPT_FOLDER: &str = "tests/scripts";
+const CERTIFICATES_GENERATOR_SCRIPT: &str = "create-test-certificates.sh";
+const OPENSSL_CONFIG: &str = "openssl.cnf";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = out_dir.to_str().unwrap();
+
+    let dest_prefix = format!("{out_dir}/");
+
+    let script_path =
+        format!("{CERTIFICATES_GENERATOR_SCRIPT_FOLDER}/{CERTIFICATES_GENERATOR_SCRIPT}");
+    let openssl_config_path = format!("{CERTIFICATES_GENERATOR_SCRIPT_FOLDER}/{OPENSSL_CONFIG}");
+
+    Command::new(script_path.clone())
+        .arg(dest_prefix)
+        .status()?;
+
+    println!("cargo::rerun-if-changed={script_path}");
+    println!("cargo::rerun-if-changed={openssl_config_path}");
+    println!("cargo::rerun-if-changed=build.rs");
+
+    Ok(())
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
 listeners:
-  - targets:
-    - url: https://www.google.com/
+  - strategy: failed_then_ok
+    targets:
+      - url: https://www.google.com/

--- a/deny.toml
+++ b/deny.toml
@@ -10,14 +10,29 @@ yanked = "deny"
 ignore = []
 
 [licenses]
-allow = [
-    "MIT",
-    "Apache-2.0",
-]
+allow = ["MIT", "Apache-2.0", "MPL-2.0", "ISC", "BSD-3-Clause"]
 confidence-threshold = 0.93
 exceptions = [
-    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+    { allow = [
+        "Unicode-DFS-2016",
+    ], name = "unicode-ident" },
+    { allow = [
+        "OpenSSL",
+    ], crate = "ring" },
 ]
+
+# Sigh
+[[licenses.clarify]]
+crate = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [licenses.private]
 ignore = false

--- a/src/config/listener.rs
+++ b/src/config/listener.rs
@@ -43,6 +43,24 @@ pub struct ListenerConfig {
     targets: TargetConfigList,
     #[serde(default)]
     response: ResponseConfig,
+    #[serde(default)]
+    tls: TlsConfig,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TlsConfig {
+    #[serde(default)]
+    pub verify: TlsVerifyConfig,
+    pub ca: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub enum TlsVerifyConfig {
+    No,
+    #[default]
+    Yes,
 }
 
 impl ListenerConfig {
@@ -105,6 +123,10 @@ impl ListenerConfig {
 
     pub fn on(&self) -> String {
         format!("{}", self.listen_on)
+    }
+
+    pub fn tls(&self) -> &TlsConfig {
+        &self.tls
     }
 
     fn validate_strategy(&self) -> Result<(), HttpDragonflyError> {

--- a/src/config/snapshots/http_dragonfly__config__headers__tests__transforms.snap
+++ b/src/config/snapshots/http_dragonfly__config__headers__tests__transforms.snap
@@ -5,7 +5,7 @@ expression: ctx
 Context(
   own: {
     "CTX_APP_NAME": "http-dragonfly",
-    "CTX_APP_VERSION": "0.2.10",
+    "CTX_APP_VERSION": "0.3.0",
     "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
     "TEST_ENV_KEY": "TEST_ENV_VALUE",
   },

--- a/src/config/target.rs
+++ b/src/config/target.rs
@@ -1,7 +1,23 @@
-use super::{headers::HeaderTransform, response::ResponseStatus, ConfigValidator};
+use super::{
+    headers::HeaderTransform,
+    listener::{TlsConfig, TlsVerifyConfig},
+    response::ResponseStatus,
+    ConfigValidator,
+};
 use crate::{context::Context, errors::HttpDragonflyError};
+use http_body_util::Full;
 use hyper::{body::Bytes, http::request::Parts, Uri};
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::{
+    client::legacy::{connect::HttpConnector, Client},
+    rt::TokioExecutor,
+};
 use jaq_interpret::{Ctx, Filter, FilterT, ParseCtx, RcIter, Val};
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::CertificateDer,
+    ClientConfig, RootCertStore, SignatureScheme,
+};
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer,
@@ -9,6 +25,9 @@ use serde::{
 use serde_json::{json, value::Value as JsonValue, Value};
 use std::{
     collections::{HashMap, HashSet},
+    fs::File,
+    io::BufReader,
+    sync::{Arc, LazyLock, RwLock},
     time::Duration,
 };
 use tracing::{debug, error};
@@ -16,6 +35,7 @@ use tracing::{debug, error};
 const DEFAULT_TARGET_TIMEOUT_SEC: u64 = 60;
 
 pub type TargetConfigList = Vec<TargetConfig>;
+type HttpsClient = Client<hyper_rustls::HttpsConnector<HttpConnector>, Full<Bytes>>;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -33,6 +53,8 @@ pub struct TargetConfig {
     on_error: TargetOnErrorAction,
     error_status: Option<ResponseStatus>,
     condition: Option<TargetConditionConfig>,
+    #[serde(default)]
+    tls: Option<TlsConfig>,
 }
 
 impl TargetConfig {
@@ -76,8 +98,8 @@ impl TargetConfig {
         &self.body
     }
 
-    pub fn timeout(&self) -> Duration {
-        self.timeout
+    pub fn timeout(&self) -> &Duration {
+        &self.timeout
     }
 
     pub fn on_error(&self) -> &TargetOnErrorAction {
@@ -90,6 +112,173 @@ impl TargetConfig {
 
     pub fn condition(&self) -> &Option<TargetConditionConfig> {
         &self.condition
+    }
+
+    /// Returns http client with configured (or default) tls config and timeout
+    pub fn https_client(&'static self, default_tls_config: &'static TlsConfig) -> HttpsClient {
+        Self::get_https_client(
+            &self.timeout(),
+            self.tls.as_ref().unwrap_or(default_tls_config),
+        )
+    }
+
+    /// Check if client with specified timeout and tls config is present in the cache
+    /// and either:
+    /// - returns clone of the cached one
+    /// - or creates new one, store ith to the cache and returns it
+    fn get_https_client(timeout: &'static Duration, tls_config: &'static TlsConfig) -> HttpsClient {
+        type HashKey = (&'static Duration, &'static TlsConfig);
+        static CACHE: LazyLock<RwLock<HashMap<HashKey, HttpsClient>>> =
+            LazyLock::new(|| RwLock::new(HashMap::new()));
+
+        let key = (timeout, tls_config);
+
+        debug!(key = ?key, "get https client");
+        let client = if CACHE.read().unwrap().get(&key).is_some() {
+            debug!(key = ?key, "get https client: found in cache");
+            let cached = CACHE.read().unwrap();
+            cached.get(&key).unwrap().clone()
+        } else {
+            {
+                let mut cache = CACHE.write().unwrap();
+                let client = Self::create_https_client(timeout, tls_config).unwrap();
+                cache.insert(key, client);
+                debug!(key = ?key, "get https client: put into the cache");
+            }
+            Self::get_https_client(timeout, tls_config)
+        };
+
+        client
+    }
+
+    /// Creates http client with specified timeout and tls config
+    fn create_https_client(
+        timeout: &Duration,
+        tls_config: &TlsConfig,
+    ) -> Result<HttpsClient, hyper::Error> {
+        let mut http_connector = HttpConnector::new();
+        http_connector.set_connect_timeout(Some(timeout.clone()));
+        http_connector.enforce_http(false);
+
+        let https_connector = match tls_config.verify {
+            TlsVerifyConfig::No => {
+                debug!("TLS verification disabled");
+                HttpsConnectorBuilder::default().with_tls_config(Self::get_dangerous_tls_config()?)
+            }
+            TlsVerifyConfig::Yes => {
+                debug!("TLS verification enabled");
+                if let Some(ca) = tls_config.ca.as_ref() {
+                    debug!(pem = %ca, "use custom Root CA bundle");
+                    HttpsConnectorBuilder::default()
+                        .with_tls_config(Self::get_custom_ca_tls_config(ca)?)
+                } else {
+                    if let Ok(connector) = HttpsConnectorBuilder::default().with_native_roots() {
+                        debug!("use native Root CA bundle");
+                        connector
+                    } else {
+                        debug!("no native CA config found, use Mozilla Root CA bundle");
+                        HttpsConnectorBuilder::default().with_webpki_roots()
+                    }
+                }
+            }
+        };
+
+        let https_connector = https_connector
+            .https_or_http()
+            .enable_http1()
+            .wrap_connector(http_connector);
+
+        let https_client = Client::builder(TokioExecutor::default()).build(https_connector);
+        Ok(https_client)
+    }
+
+    fn get_dangerous_tls_config() -> Result<ClientConfig, hyper::Error> {
+        let store = RootCertStore::empty();
+
+        let mut config = ClientConfig::builder()
+            .with_root_certificates(store)
+            .with_no_client_auth();
+
+        // this completely disables cert-verification
+        let mut dangerous_config = ClientConfig::dangerous(&mut config);
+        dangerous_config.set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+
+        Ok(config)
+    }
+
+    fn get_custom_ca_tls_config(ca_path: impl Into<String>) -> Result<ClientConfig, hyper::Error> {
+        let cert_file = File::open(ca_path.into()).unwrap();
+        let cert_file_reader = &mut BufReader::new(cert_file);
+        let certs: Vec<CertificateDer> = rustls_pemfile::certs(cert_file_reader)
+            .map(|c| c.expect("Failed to parse a certificate from the certificate file."))
+            .collect();
+        assert!(
+            certs.len() > 0,
+            "No certificates were found in the certificate file."
+        );
+
+        let mut store = RootCertStore::empty();
+        for cert in certs {
+            store.add(cert).unwrap();
+        }
+
+        let config = ClientConfig::builder()
+            .with_root_certificates(store)
+            .with_no_client_auth();
+
+        Ok(config)
+    }
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification {}
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
     }
 }
 
@@ -321,6 +510,7 @@ pub mod test_target {
             on_error: TargetOnErrorAction::Propagate,
             error_status: None,
             condition: Some(TargetConditionConfig::Default),
+            tls: Default::default(),
         }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -202,7 +202,7 @@ impl RequestHandler {
             // Prepare target request
             let http_client = target.https_client(self.listener_cfg.tls());
             let http_request = http_client.request(target_request);
-            let http_request = tokio::time::timeout(target.timeout().clone(), http_request);
+            let http_request = tokio::time::timeout(*target.timeout(), http_request);
 
             target_requests.push(tokio::spawn(http_request));
             target_ctx.push(ctx);

--- a/src/snapshots/http_dragonfly__config__test__good_config@01-minimal.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@01-minimal.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/01-minimal.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@02-simple-config.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@02-simple-config.yaml.snap
@@ -69,6 +69,7 @@ Ok(
                             555,
                         ),
                         condition: None,
+                        tls: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -202,6 +203,7 @@ Ok(
                                 },
                             ),
                         ),
+                        tls: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -231,6 +233,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -262,7 +265,7 @@ Ok(
                                             "X-Http-Splitter-Version",
                                         ),
                                         value: Some(
-                                            "0.2.10",
+                                            "0.3.0",
                                         ),
                                     },
                                     HeaderTransform {
@@ -277,6 +280,10 @@ Ok(
                             ),
                         },
                     ),
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@10-strategy-always_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@10-strategy-always_override.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/10-strategy-always_override.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@20-strategy-always_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@20-strategy-always_target_id.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/20-strategy-always_target_id.yaml
 ---
 Ok(
@@ -28,6 +28,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -37,6 +38,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@30-strategy-ok_then_failed.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@30-strategy-ok_then_failed.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/30-strategy-ok_then_failed.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@40-strategy-ok_then_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@40-strategy-ok_then_target_id.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/40-strategy-ok_then_target_id.yaml
 ---
 Ok(
@@ -28,6 +28,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -37,6 +38,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@50-strategy-ok_then_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@50-strategy-ok_then_override.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/50-strategy-ok_then_override.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@60-strategy-failed_then_ok.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@60-strategy-failed_then_ok.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/60-strategy-failed_then_ok.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@70-strategy-failed_then_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@70-strategy-failed_then_target_id.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/70-strategy-failed_then_target_id.yaml
 ---
 Ok(
@@ -28,6 +28,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -37,6 +38,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@80-strategy-failed_then_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@80-strategy-failed_then_override.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::owned(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/80-strategy-failed_then_override.yaml
 ---
 Ok(
@@ -26,6 +26,7 @@ Ok(
                         on_error: Propagate,
                         error_status: None,
                         condition: None,
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -33,6 +34,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__config__test__good_config@90-strategy-conditional_routing.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@90-strategy-conditional_routing.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config.rs
-expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), &ctx)"
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
 input_file: tests/configs/good/90-strategy-conditional_routing.yaml
 ---
 Ok(
@@ -30,6 +30,7 @@ Ok(
                         condition: Some(
                             Default,
                         ),
+                        tls: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -163,6 +164,7 @@ Ok(
                                 },
                             ),
                         ),
+                        tls: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -296,6 +298,7 @@ Ok(
                                 },
                             ),
                         ),
+                        tls: None,
                     },
                 ],
                 response: ResponseConfig {
@@ -303,6 +306,10 @@ Ok(
                     failed_status_regex: "4\\d{2}|5\\d{2}",
                     no_targets_status: 500,
                     override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
                 },
             },
         ],

--- a/src/snapshots/http_dragonfly__context__test_context__context_with.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__context_with.snap
@@ -9,7 +9,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.2.10",
+      "CTX_APP_VERSION": "0.3.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__context_with_test_environment.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__context_with_test_environment.snap
@@ -5,7 +5,7 @@ expression: get_test_ctx()
 Context(
   own: {
     "CTX_APP_NAME": "http-dragonfly",
-    "CTX_APP_VERSION": "0.2.10",
+    "CTX_APP_VERSION": "0.3.0",
     "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
     "TEST_ENV_KEY": "TEST_ENV_VALUE",
   },

--- a/src/snapshots/http_dragonfly__context__test_context__request_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__request_context.snap
@@ -15,7 +15,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.2.10",
+      "CTX_APP_VERSION": "0.3.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__response_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__response_context.snap
@@ -10,7 +10,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.2.10",
+      "CTX_APP_VERSION": "0.3.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__target_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__target_context.snap
@@ -10,7 +10,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.2.10",
+      "CTX_APP_VERSION": "0.3.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,36 +1,11 @@
 mod common;
 
-use std::env;
-
 use crate::common::run_test_with_config;
+use common::{init_logging, test_one_case, TestConfig};
 use futures_util::future::join_all;
-use reqwest::{header::HeaderValue, Client};
 
 const TEST_CONFIG_PATH: &str = "tests/configs/integration/basic.yaml";
-
-struct TestConfig {
-    description: &'static str,
-    port: u16,
-    include_wrong_port: bool,
-    include_timeout_target: bool,
-    include_good_target: bool,
-    expected_status: u16,
-    expected_x_target_id_header: Option<&'static str>,
-}
-
-impl Default for TestConfig {
-    fn default() -> Self {
-        Self {
-            description: "UNDEFINED",
-            port: 0,
-            include_wrong_port: false,
-            include_timeout_target: false,
-            include_good_target: true,
-            expected_status: 200,
-            expected_x_target_id_header: Some("GOOD"),
-        }
-    }
-}
+const TEST_PORT: u16 = 3000;
 
 fn prepare_test_cases() -> Vec<TestConfig> {
     vec![
@@ -258,56 +233,15 @@ fn prepare_test_cases() -> Vec<TestConfig> {
     ]
 }
 
-async fn test_one_strategy(client: &Client, test_config: TestConfig) {
-    let mut req = client.get(format!("http://localhost:{}/", test_config.port));
-    if test_config.include_wrong_port {
-        req = req.header("x-include-wrong-port", "yes")
-    }
-    if test_config.include_timeout_target {
-        req = req.header("x-include-timeout", "yes")
-    }
-    if test_config.include_good_target {
-        req = req.header("x-include-good", "yes")
-    }
-
-    let resp = req.send().await.unwrap();
-    assert_eq!(
-        resp.status().as_u16(),
-        test_config.expected_status,
-        "{}: request to port {}, `{}` status expected, with: wrong_port={}, timeout_target={}, good_target={}",
-        test_config.description,
-        test_config.port,
-        test_config.expected_status,
-        test_config.include_wrong_port,
-        test_config.include_timeout_target,
-        test_config.include_good_target
-    );
-
-    let target_id_header = test_config
-        .expected_x_target_id_header
-        .map(|target_id| HeaderValue::from_str(target_id).unwrap());
-
-    assert_eq!(
-        resp.headers().get("x-target-id"),
-        target_id_header.as_ref(),
-        "{}: request to port {}, expected X-Target-Id header `{:?}`",
-        test_config.description,
-        test_config.port,
-        test_config.expected_x_target_id_header
-    );
-}
-
 #[tokio::test]
 async fn basic_functionality() {
-    if env::var("RUST_LOG").is_ok() {
-        tracing_subscriber::fmt::init();
-    }
+    init_logging();
 
-    let result = run_test_with_config(TEST_CONFIG_PATH, 3000, 60, async {
+    let result = run_test_with_config(TEST_CONFIG_PATH, TEST_PORT, 60, false, async {
         let client = reqwest::Client::new();
         let tasks: Vec<_> = prepare_test_cases()
             .into_iter()
-            .map(|t| test_one_strategy(&client, t))
+            .map(|t| test_one_case(&client, t))
             .collect();
         join_all(tasks).await;
     })

--- a/tests/basic_config.rs
+++ b/tests/basic_config.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::env;
+
 use crate::common::run_test_with_config;
 use futures_util::future::join_all;
 use reqwest::{header::HeaderValue, Client};
@@ -297,6 +299,10 @@ async fn test_one_strategy(client: &Client, test_config: TestConfig) {
 
 #[tokio::test]
 async fn basic_functionality() {
+    if env::var("RUST_LOG").is_ok() {
+        tracing_subscriber::fmt::init();
+    }
+
     let result = run_test_with_config(TEST_CONFIG_PATH, 3000, 60, async {
         let client = reqwest::Client::new();
         let tasks: Vec<_> = prepare_test_cases()

--- a/tests/common/echo_server.rs
+++ b/tests/common/echo_server.rs
@@ -20,7 +20,7 @@ pub async fn echo_server(port: u16) -> Result<(), Error> {
     let socket = SocketAddr::new(ip.into(), port);
     let listener = TcpListener::bind(&socket)
         .await
-        .expect("unable to create health check listener");
+        .expect("unable to create echo server listener");
     let mut signal_handler = SignalHandler::new("health");
     let mut join_set = JoinSet::new();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,17 +1,81 @@
 pub mod echo_server;
 
-use echo_server::echo_server;
+use echo_server::{echo_server, tls_echo_server};
 use futures_util::Future;
 use http_dragonfly::{cli::CliConfig, context::RootOsEnvironment};
-use std::time::Duration;
+use hyper::header::HeaderValue;
+use reqwest::Client;
+use std::{env, io, sync::LazyLock, time::Duration};
+
+const SERVER_CERT_BUNDLE: &str = "/end.crt";
+const SERVER_PRIVATE_KEY: &str = "/test-server.key";
+
+pub struct TestConfig {
+    pub description: &'static str,
+    pub port: u16,
+    pub include_wrong_port: bool,
+    pub include_timeout_target: bool,
+    pub include_good_target: bool,
+    pub expected_status: u16,
+    pub expected_x_target_id_header: Option<&'static str>,
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            description: "UNDEFINED",
+            port: 0,
+            include_wrong_port: false,
+            include_timeout_target: false,
+            include_good_target: true,
+            expected_status: 200,
+            expected_x_target_id_header: Some("GOOD"),
+        }
+    }
+}
+
+pub fn init_logging() -> bool {
+    static INITIALIZED: LazyLock<bool> = LazyLock::new(|| {
+        if env::var("RUST_LOG").is_ok() {
+            tracing_subscriber::fmt::init();
+        };
+        true
+    });
+
+    *INITIALIZED
+}
 
 pub async fn run_test_with_config(
     config_path: &str,
     echo_port: u16,
     timeout_sec: u64,
+    is_tls: bool,
     test: impl Future,
 ) -> Result<(), String> {
-    let echo_server = echo_server(echo_port);
+    if is_tls {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let cert_path = format!("{out_dir}/{SERVER_CERT_BUNDLE}");
+        let key_path = format!("{out_dir}/{SERVER_PRIVATE_KEY}");
+
+        run_test_with_config_and_server(
+            config_path,
+            timeout_sec,
+            tls_echo_server(echo_port, cert_path, key_path),
+            test,
+        )
+        .await
+    } else {
+        run_test_with_config_and_server(config_path, timeout_sec, echo_server(echo_port), test)
+            .await
+    }
+}
+
+async fn run_test_with_config_and_server(
+    config_path: &str,
+    timeout_sec: u64,
+    echo_server: impl Future<Output = Result<(), io::Error>>,
+    test: impl Future,
+) -> Result<(), String> {
     let cli_config = CliConfig::from_config_path(config_path.into());
     let env_provider = RootOsEnvironment::new("^TEST_HTTP_ENV_[A-Z0-9]+$");
     let server = http_dragonfly::run(cli_config, env_provider);
@@ -23,4 +87,43 @@ pub async fn run_test_with_config(
         _ = timer => Err("test has been timed out".into()),
         _result = test => Ok(())
     }
+}
+
+pub async fn test_one_case(client: &Client, test_config: TestConfig) {
+    let mut req = client.get(format!("http://localhost:{}/", test_config.port));
+    if test_config.include_wrong_port {
+        req = req.header("x-include-wrong-port", "yes")
+    }
+    if test_config.include_timeout_target {
+        req = req.header("x-include-timeout", "yes")
+    }
+    if test_config.include_good_target {
+        req = req.header("x-include-good", "yes")
+    }
+
+    let resp = req.send().await.unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        test_config.expected_status,
+        "{}: request to port {}, `{}` status expected, with: wrong_port={}, timeout_target={}, good_target={}",
+        test_config.description,
+        test_config.port,
+        test_config.expected_status,
+        test_config.include_wrong_port,
+        test_config.include_timeout_target,
+        test_config.include_good_target
+    );
+
+    let target_id_header = test_config
+        .expected_x_target_id_header
+        .map(|target_id| HeaderValue::from_str(target_id).unwrap());
+
+    assert_eq!(
+        resp.headers().get("x-target-id"),
+        target_id_header.as_ref(),
+        "{}: request to port {}, expected X-Target-Id header `{:?}`",
+        test_config.description,
+        test_config.port,
+        test_config.expected_x_target_id_header
+    );
 }

--- a/tests/configs/integration/basic.yaml
+++ b/tests/configs/integration/basic.yaml
@@ -16,60 +16,60 @@ listeners:
     listen_on: "*:8000"
     strategy: failed_then_ok
     targets:
-    - url: http://localhost:3000/${CTX_REQUEST_HEADERS_X_DELAY}
-      timeout: 1s
-      body: "GOOD"
-      headers:
-        - drop: content-length
-        - add: X-Path
-          value: ${CTX_REQUEST_PATH}
+      - url: http://localhost:3000/${CTX_REQUEST_HEADERS_X_DELAY}
+        timeout: 1s
+        body: "GOOD"
+        headers:
+          - drop: content-length
+          - add: X-Path
+            value: ${CTX_REQUEST_PATH}
 
   # Failed first, ok
   - id: three-targets-8001
     listen_on: "*:8001"
     strategy: failed_then_ok
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # Failed first, target id
   - id: three-targets-8002
     listen_on: "*:8002"
     strategy: failed_then_target_id
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       target_selector: GOOD
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # Failed first, override
   - id: three-targets-8003
@@ -78,72 +78,72 @@ listeners:
     headers:
       - drop: content-length
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # ok first, failed
   - id: three-targets-8004
     listen_on: "*:8004"
     strategy: ok_then_failed
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # ok first, target_id
   - id: three-targets-8005
     listen_on: "*:8005"
     strategy: ok_then_target_id
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       target_selector: WRONG
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # ok first, override
   - id: three-targets-8006
@@ -152,49 +152,49 @@ listeners:
     headers:
       - drop: content-length
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # always, target_id
   - id: three-targets-8007
     listen_on: "*:8007"
     strategy: always_target_id
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       target_selector: GOOD
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # always, override
   - id: three-targets-8008
@@ -203,25 +203,25 @@ listeners:
     headers:
       - drop: content-length
     targets:
-    - id: "GOOD"
-      url: http://localhost:3000/
-      body: GOOD
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "WRONG"
-      url: http://localhost:65535/
-      body: WRONG
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "TIMEOUT"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: TIMEOUT
-      condition: .request.headers["x-include-timeout"] == "yes"
+      - id: "GOOD"
+        url: http://localhost:3000/
+        body: GOOD
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "WRONG"
+        url: http://localhost:65535/
+        body: WRONG
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "TIMEOUT"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: TIMEOUT
+        condition: .request.headers["x-include-timeout"] == "yes"
     response:
       override:
         status: 222
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # conditional_routing
   - id: conditional-8009
@@ -230,28 +230,28 @@ listeners:
     headers:
       - drop: content-length
     targets:
-    - id: "1"
-      url: http://localhost:3000/
-      body: "1"
-      condition: .request.headers["x-include-good"] == "yes"
-    - id: "2"
-      url: http://localhost:65535/
-      body: "2"
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-    - id: "3"
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: "3"
-      condition: .request.headers["x-include-timeout"] == "yes"
-    - id: default
-      url: http://localhost:3000/
-      body: default
-      condition: default
+      - id: "1"
+        url: http://localhost:3000/
+        body: "1"
+        condition: .request.headers["x-include-good"] == "yes"
+      - id: "2"
+        url: http://localhost:65535/
+        body: "2"
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+      - id: "3"
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: "3"
+        condition: .request.headers["x-include-timeout"] == "yes"
+      - id: default
+        url: http://localhost:3000/
+        body: default
+        condition: default
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
 
   # conditional_routing, with different statuses
   - id: conditional-8010
@@ -260,25 +260,25 @@ listeners:
     headers:
       - drop: content-length
     targets:
-    - id: timeout_with_555_status
-      timeout: 1s
-      url: http://localhost:3000/2
-      body: "timeout_with_555_status"
-      condition: .request.headers["x-include-timeout"] == "yes"
-      on_error: status
-      error_status: 555
-    - id: wrong_port_with_dropped_status
-      timeout: 1s
-      url: http://localhost:65535/
-      body: "wrong_port_with_dropped_status"
-      condition: .request.headers["x-include-wrong-port"] == "yes"
-      on_error: drop
-    - id: default
-      url: http://localhost:3000/
-      body: default
-      condition: default
+      - id: timeout_with_555_status
+        timeout: 1s
+        url: http://localhost:3000/2
+        body: "timeout_with_555_status"
+        condition: .request.headers["x-include-timeout"] == "yes"
+        on_error: status
+        error_status: 555
+      - id: wrong_port_with_dropped_status
+        timeout: 1s
+        url: http://localhost:65535/
+        body: "wrong_port_with_dropped_status"
+        condition: .request.headers["x-include-wrong-port"] == "yes"
+        on_error: drop
+      - id: default
+        url: http://localhost:3000/
+        body: default
+        condition: default
     response:
       override:
         headers:
-        - add: x-target-id
-          value: ${CTX_TARGET_ID}
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}

--- a/tests/configs/integration/tls.yaml
+++ b/tests/configs/integration/tls.yaml
@@ -1,0 +1,104 @@
+# Requires TLS echo server on port 3001
+
+# 9000 - fails due to unknown cert
+# 9001 - disabled tls verification
+# 9002 - use custom listener CA bundle
+# 9003 - use custom listener CA w/o intermediate
+# 9004 - disabled target tls verification
+# 9005 - valid target cert bundle
+
+listeners:
+  # fails due to unknown cert
+  - id: basic-forwarding-9000
+    listen_on: "*:9000"
+    strategy: failed_then_ok
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+
+  # disabled tls verification
+  - id: disabled-tls-verification-9001
+    listen_on: "*:9001"
+    tls:
+      verify: no
+    strategy: ok_then_failed
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: GOOD
+    response:
+      override:
+        headers:
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
+
+  # use custom listener CA bundle
+  - id: use-custom-ca-bundle-9002
+    listen_on: "*:9002"
+    tls:
+      ca: tests/tls/ca.pem
+    strategy: failed_then_ok
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: GOOD
+        headers:
+          - drop: content-length
+          - add: X-Path
+            value: ${CTX_REQUEST_PATH}
+    response:
+      override:
+        headers:
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
+
+  # use custom listener CA w/o intermediate
+  - id: use-custom-ca-9003
+    listen_on: "*:9003"
+    tls:
+      ca: tests/tls/ca.crt
+    strategy: failed_then_ok
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: GOOD
+        headers:
+          - drop: content-length
+          - add: X-Path
+            value: ${CTX_REQUEST_PATH}
+    response:
+      override:
+        headers:
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
+
+  # disabled target tls verification
+  - id: disabled-target-tls-verification-9004
+    listen_on: "*:9004"
+    strategy: ok_then_failed
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: WRONG
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: GOOD
+        tls:
+          verify: no
+    response:
+      override:
+        headers:
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}
+
+  # valid target cert bundle
+  - id: valid-target-cert-9005
+    listen_on: "*:9005"
+    strategy: ok_then_failed
+    targets:
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: WRONG
+      - url: https://localhost:3001/${CTX_REQUEST_HEADERS_X_DELAY}
+        id: GOOD
+        tls:
+          verify: yes
+          ca: tests/tls/ca.pem
+    response:
+      override:
+        headers:
+          - add: x-target-id
+            value: ${CTX_TARGET_ID}

--- a/tests/scripts/create-test-certificates.sh
+++ b/tests/scripts/create-test-certificates.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# 1 - files prefix
+#     may include path to destination folder
+#     or may be used to generate multiple bundles at the same location
+
+prefix="${1}"
+basedir=$(dirname ${0})
+
+openssl req -nodes -x509 -days 3650 -sha256 -batch -subj "/CN=Test RSA root CA" \
+            -newkey rsa:4096 -keyout ${prefix}ca.key -out ${prefix}ca.crt
+
+openssl req -nodes -sha256 -batch -subj "/CN=Test RSA intermediate CA" \
+            -newkey rsa:3072 -keyout ${prefix}inter.key -out ${prefix}inter.req
+
+openssl req -nodes -sha256 -batch -subj "/CN=test-server.com" \
+            -newkey rsa:2048 -keyout ${prefix}end.key -out ${prefix}end.req
+
+openssl rsa -in ${prefix}end.key -out ${prefix}test-server.key
+
+openssl x509 -req -sha256 -days 3650 -set_serial 123 -extensions v3_inter -extfile ${basedir}/openssl.cnf \
+             -CA ${prefix}ca.crt -CAkey ${prefix}ca.key -in ${prefix}inter.req -out ${prefix}inter.crt
+
+openssl x509 -req -sha256 -days 2000 -set_serial 456 -extensions v3_end -extfile ${basedir}/openssl.cnf \
+             -CA ${prefix}inter.crt -CAkey ${prefix}inter.key -in ${prefix}end.req -out ${prefix}end.crt
+
+cat ${prefix}end.crt ${prefix}inter.crt > ${prefix}test-server.pem
+cat ${prefix}inter.crt ${prefix}ca.crt > ${prefix}ca.pem
+rm ${prefix}*.req ${prefix}ca.key ${prefix}inter.key ${prefix}end.key
+
+mkdir tests/tls
+cp ${prefix}ca.* tests/tls/

--- a/tests/scripts/openssl.cnf
+++ b/tests/scripts/openssl.cnf
@@ -1,0 +1,25 @@
+[ v3_end ]
+basicConstraints = critical,CA:false
+keyUsage = nonRepudiation, digitalSignature
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+subjectAltName = @alt_names
+
+[ v3_client ]
+basicConstraints = critical,CA:false
+keyUsage = nonRepudiation, digitalSignature
+extendedKeyUsage = critical, clientAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+
+[ v3_inter ]
+subjectKeyIdentifier = hash
+extendedKeyUsage = critical, serverAuth, clientAuth
+basicConstraints = CA:true
+keyUsage = cRLSign, keyCertSign, digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign, cRLSign
+
+[ alt_names ]
+DNS.1 = test-server.com
+DNS.2 = second.test-server.com
+DNS.3 = localhost
+DNS.4 = 127.0.0.1

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,63 @@
+mod common;
+
+use crate::common::run_test_with_config;
+use common::{init_logging, test_one_case, TestConfig};
+use futures_util::future::join_all;
+
+const TEST_CONFIG_PATH: &str = "tests/configs/integration/tls.yaml";
+const TEST_PORT: u16 = 3001;
+
+fn prepare_test_cases() -> Vec<TestConfig> {
+    vec![
+        TestConfig {
+            description: "invalid cert with verification enabled",
+            port: 9000,
+            expected_status: 502,
+            expected_x_target_id_header: None,
+            ..TestConfig::default()
+        },
+        TestConfig {
+            description: "invalid cert with verification disabled",
+            port: 9001,
+            ..TestConfig::default()
+        },
+        TestConfig {
+            description: "valid listener cert with ca bundle",
+            port: 9002,
+            ..TestConfig::default()
+        },
+        TestConfig {
+            description: "valid listener cert w/o ca bundle",
+            port: 9003,
+            expected_status: 502,
+            ..TestConfig::default()
+        },
+        TestConfig {
+            description: "invalid cert with target verification disabled",
+            port: 9004,
+            ..TestConfig::default()
+        },
+        TestConfig {
+            description: "valid target cert bundle with absent listener cert",
+            port: 9005,
+            ..TestConfig::default()
+        },
+    ]
+}
+
+#[tokio::test]
+async fn custom_tls_config() {
+    init_logging();
+
+    let result = run_test_with_config(TEST_CONFIG_PATH, TEST_PORT, 60, true, async {
+        let client = reqwest::Client::new();
+        let tasks: Vec<_> = prepare_test_cases()
+            .into_iter()
+            .map(|t| test_one_case(&client, t))
+            .collect();
+        join_all(tasks).await;
+    })
+    .await;
+
+    assert_eq!(result, Ok(()))
+}


### PR DESCRIPTION
1. Add per-listener configuration with custom root CA bundle or disabled TLS verification.
2. Add per-target TLS config that overrides listeners' one.
3. Change default client TLS config to:
  - skip TLS verification if it's disabled in listener or target config;
  - else, use custom root CA certificate bundle (file in PEM format) if it's defined in listener or target config;
  - else, use OS native certificates bundle if it's present;
  - else, use Mozila root CA bundle.