### PR TITLE
chore: Refactor to use std::sync::OnceLock instead of once_cell::sync::OnceCell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
 dependencies = [
  "shlex",
 ]
@@ -576,7 +576,6 @@ dependencies = [
  "insta",
  "jaq-interpret",
  "jaq-parse",
- "once_cell",
  "regex",
  "reqwest",
  "rustls",
@@ -1072,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1539,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ hyper-util = { version = "0.1.7", features = [
 ] }
 jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
-once_cell = "1.19.0"
 regex = "1.10.6"
 rustls = { version = "0.23.12", default-features = false, features = [
     "ring",
@@ -43,7 +42,7 @@ rustls = { version = "0.23.12", default-features = false, features = [
 rustls-pemfile = "2.1.3"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
-serde_yaml = "0.9.34"
+serde_yaml = "0.9.33"
 shellexpand = { version = "3.1.0", default-features = false, features = [
     "base-0",
 ] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,17 +5,17 @@ pub mod target;
 
 use crate::context::Context;
 use listener::ListenerConfig;
-use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use shellexpand::env_with_context_no_errors;
 use std::{
     fs::File,
     io,
     io::{BufReader, Read},
+    sync::OnceLock,
 };
 use tracing::{debug, info};
 
-static APP_CONFIG: OnceCell<AppConfig> = OnceCell::new();
+static APP_CONFIG: OnceLock<AppConfig> = OnceLock::new();
 
 #[derive(thiserror::Error)]
 pub enum ConfigError {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,9 @@
 use crate::config::target::TargetConfig;
 use http_body_util::Full;
 use hyper::{body::Bytes, http::request::Parts, Response};
-use once_cell::sync::OnceCell;
 use regex::Regex;
 use serde::Serialize;
-use std::{collections::HashMap, env, net::SocketAddr};
+use std::{collections::HashMap, env, net::SocketAddr, sync::OnceLock};
 use tracing::{debug, info};
 
 const CTX_APP_NAME: &str = env!("CARGO_PKG_NAME");
@@ -20,7 +19,7 @@ pub struct Context<'a> {
 
 impl<'a> Context<'a> {
     pub fn root(root_env: impl RootEnvironment) -> &'static Context<'a> {
-        static ROOT_CONTEXT: OnceCell<Context> = OnceCell::new();
+        static ROOT_CONTEXT: OnceLock<Context> = OnceLock::new();
 
         let ctx = ROOT_CONTEXT.get_or_init(|| {
             let mut ctx = ContextMap::new();


### PR DESCRIPTION
Refactor to use std::sync::OnceLock instead of once_cell::sync::OnceCell