### PR TITLE
feat: Implement target request signing with AWS SigV4

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -5,11 +5,12 @@ description: Run the full local CI-equivalent check for http-dragonfly (build, t
 
 Run these in order and report pass/fail for each. Stop and report immediately if one fails — don't run the rest until it's fixed, except where noted.
 
-1. `cargo build`
-2. `cargo test` — if it fails on insta snapshot mismatches, show the diff and ask before running `cargo insta accept`.
-3. `cargo fmt --all -- --check`
-4. `cargo clippy --all-targets -- -D warnings`
-5. `pre-commit run --all-files`
+1. `cargo clean`
+2. `cargo build`
+3. `cargo test` — if it fails on insta snapshot mismatches, show the diff and ask before running `cargo insta accept`.
+4. `cargo fmt --all -- --check`
+5. `cargo clippy --all-targets -- -D warnings`
+6. `pre-commit run --all-files`
 
 Steps 1-4 mirror exactly what `.github/workflows/ci.yaml` runs on every PR. Step 5 runs the local dev-workflow gate from `.pre-commit-config.yaml` (trailing whitespace, check-yaml/toml/json, large-file/secret detection, plus `cargo fmt --` and `cargo check` again).
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ mutants.out/
 mutants.out.old/
 
 .DS_Store
+
+docs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -165,15 +166,20 @@ dependencies = [
  "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.2",
+ "p256",
+ "rand 0.8.7",
  "sha1",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -235,6 +241,32 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdce92c2b36186558b99c36a144b3a7343f2425b0613108d39b67e45c333170d"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -329,11 +361,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
@@ -587,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +639,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -875,6 +919,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -921,6 +971,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -986,6 +1048,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,7 +1074,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1011,7 +1086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1051,10 +1126,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1112,6 +1221,16 @@ dependencies = [
  "portable-atomic",
  "rand 0.10.2",
  "web-time",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1243,6 +1362,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1298,6 +1418,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1476,15 @@ name = "hifijson"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -2106,6 +2246,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parse-display"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2280,15 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2211,6 +2372,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2367,11 +2547,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2388,12 +2579,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2511,6 +2721,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2701,6 +2921,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3087,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -2891,6 +3136,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2935,6 +3190,16 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "rustix",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +145,49 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-config"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -112,10 +213,394 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.2",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -124,6 +609,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bitflags",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -147,6 +733,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -179,8 +775,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -191,6 +787,7 @@ checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -244,6 +841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +872,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -298,11 +907,113 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -317,6 +1028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +1049,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -360,10 +1088,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.2",
+ "web-time",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -399,12 +1148,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -412,6 +1177,23 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -442,11 +1224,25 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -464,6 +1260,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -471,8 +1279,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -500,13 +1308,19 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -521,10 +1335,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hifijson"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -538,12 +1387,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -554,16 +1414,19 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-dragonfly"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
  "clap",
  "futures-util",
  "http-body-util",
@@ -585,6 +1448,7 @@ dependencies = [
  "shellexpand",
  "strum",
  "strum_macros",
+ "testcontainers-modules",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -622,6 +1486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,8 +1505,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -644,12 +1517,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -658,6 +1545,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -670,8 +1570,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -683,6 +1583,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -792,6 +1707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,12 +1735,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -855,6 +1789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,7 +1822,7 @@ checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
 dependencies = [
  "foldhash",
  "hifijson",
- "indexmap",
+ "indexmap 2.14.0",
  "jaq-core",
  "jaq-std",
  "serde_json",
@@ -1023,6 +1966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +2004,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +2098,37 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1130,16 +2179,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -1151,12 +2232,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1189,7 +2317,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1227,9 +2355,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1239,7 +2383,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1254,7 +2417,27 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1303,8 +2486,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1393,7 +2576,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1492,6 +2677,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,16 +2773,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1671,6 +2957,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "strum"
@@ -1776,6 +3085,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "ferroid",
+ "futures",
+ "http 1.4.2",
+ "itertools",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
+dependencies = [
+ "testcontainers",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +3151,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1868,6 +3247,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +3272,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,11 +3319,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1905,8 +3339,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -2019,6 +3453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +3483,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.2",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +3519,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2059,6 +3527,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2080,7 +3554,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand",
+ "rand 0.10.2",
  "wasm-bindgen",
 ]
 
@@ -2089,6 +3563,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -2123,6 +3609,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2218,6 +3713,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +3736,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2379,10 +3896,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -2405,6 +3944,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,15 @@ keywords = ["http", "splitter", "relay", "router"]
 license = "MIT OR Apache-2.0"
 name = "http-dragonfly"
 repository = "https://github.com/alex-karpenko/http-dragonfly"
-version = "0.4.5"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.104"
+aws-config = "1.10.1"
+aws-credential-types = "1.3.0"
+aws-sigv4 = "1.5.1"
 clap = { version = "4.6.4", features = ["derive"] }
 futures-util = "0.3.33"
 http-body-util = "0.1.4"
@@ -46,6 +49,7 @@ uuid = { version = "1.24.0", features = ["v4", "fast-rng"] }
 [dev-dependencies]
 insta = { version = "1.48.0", features = ["glob", "ron", "redactions", "filters"] }
 reqwest = "0.13.4"
+testcontainers-modules = { version = "0.15.0", features = ["localstack"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs", "tls12"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.24.0", features = ["v4", "fast-rng"] }
 
+[features]
+# Enables aws-config's browser-based "login session" credential provider.
+# Off by default: it's only needed to test aws_sigv4 signing locally against a
+# profile that uses `login_session` (see README), and it pulls in an extra AWS
+# SDK crate (aws-sdk-signin) that normal deployments don't need.
+credentials-login = ["aws-config/credentials-login"]
+
 [dev-dependencies]
 insta = { version = "1.48.0", features = ["glob", "ron", "redactions", "filters"] }
 reqwest = "0.13.4"

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Target config includes the following parameters:
   mandatory) this is something like `500`
 - `condition`: predicate expression to calculate before request, if value is `false` this target will be excluded from
   the list of allowed targets, default is `true`, see details below
+- `aws_sigv4`: sign the request to this target with AWS Signature Version 4, optional, see below for details
 
 ##### Listener: `targets.on_error`
 
@@ -507,6 +508,49 @@ Condition examples:
 - `.body.some.body.int.value == 5`
 - `.body.data.products[]|length > 0`
 - `default`
+
+##### Listener: `targets.aws_sigv4`
+
+Format: object with `service` (required), `region` (optional), `role_arn` (optional).
+
+Default: unset — the request is sent unsigned.
+
+If set, `http-dragonfly` signs the outgoing request to this target with
+[AWS Signature Version 4](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html),
+which is required by many AWS services when called directly (S3, API Gateway, OpenSearch, etc.).
+
+- `service`: the AWS SigV4 service signing name, e.g. `s3`, `execute-api`, `es`, `aoss`.
+- `region`: the AWS region to sign for. If omitted, falls back to whatever the AWS SDK's
+  default region resolution finds (`AWS_REGION`/`AWS_DEFAULT_REGION` environment variable,
+  `~/.aws/config` profile, or EC2/ECS instance metadata). If neither is available, startup
+  fails with a validation error.
+- `role_arn`: optional IAM role to assume (via STS `AssumeRole`) before signing, if the
+  credentials that should sign this target's requests differ from the process's default
+  identity.
+
+Credentials are **never** configured explicitly in `http-dragonfly`'s own config — only the
+AWS SDK's standard credential resolution is used (environment variables, `~/.aws/credentials`
+and `~/.aws/config`, SSO, EC2/ECS/container instance metadata, etc.), exactly as the AWS CLI
+and other AWS SDKs resolve credentials by default.
+
+The AWS SDK is only initialized if at least one target in the whole configuration has
+`aws_sigv4` set. Credentials are cached and shared across all targets that resolve to the
+same identity (the default identity, or a given `role_arn`) to avoid hammering STS/IMDS with
+requests, and are refreshed proactively once half of their validity window has elapsed.
+
+Example:
+
+```yaml
+targets:
+  - url: https://my-bucket.s3.us-east-1.amazonaws.com/some/key
+    aws_sigv4:
+      service: s3
+  - url: https://search-my-domain.us-west-2.es.amazonaws.com/_search
+    aws_sigv4:
+      service: es
+      region: us-west-2
+      role_arn: arn:aws:iam::123456789012:role/my-opensearch-role
+```
 
 ##### Listener: `target` config examples
 

--- a/README.md
+++ b/README.md
@@ -533,6 +533,11 @@ AWS SDK's standard credential resolution is used (environment variables, `~/.aws
 and `~/.aws/config`, SSO, EC2/ECS/container instance metadata, etc.), exactly as the AWS CLI
 and other AWS SDKs resolve credentials by default.
 
+If you test locally against a profile that has a `login_session` entry in `~/.aws/config`
+(AWS CLI's browser-based login flow), build with `--features credentials-login` — that
+provider is gated behind an off-by-default Cargo feature since it pulls in an extra AWS SDK
+crate that release builds don't need.
+
 The AWS SDK is only initialized if at least one target in the whole configuration has
 `aws_sigv4` set. Credentials are cached and shared across all targets that resolve to the
 same identity (the default identity, or a given `role_arn`) to avoid hammering STS/IMDS with

--- a/src/aws_auth/cache.rs
+++ b/src/aws_auth/cache.rs
@@ -1,0 +1,273 @@
+use aws_credential_types::{
+    provider::{self, future, ProvideCredentials},
+    Credentials,
+};
+use std::{
+    fmt,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+#[derive(Debug)]
+struct CachedEntry {
+    credentials: Credentials,
+    refresh_at: Option<SystemTime>,
+    expires_at: Option<SystemTime>,
+}
+
+/// Wraps an inner [`ProvideCredentials`] and caches its result, refreshing
+/// proactively at half of the credentials' remaining validity window
+/// instead of waiting until they're about to expire.
+pub(crate) struct RefreshingCredentials {
+    inner: Arc<dyn ProvideCredentials>,
+    cache: RwLock<Option<CachedEntry>>,
+    label: String,
+}
+
+impl fmt::Debug for RefreshingCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshingCredentials")
+            .field("label", &self.label)
+            .finish()
+    }
+}
+
+impl RefreshingCredentials {
+    pub(crate) fn new(inner: Arc<dyn ProvideCredentials>, label: impl Into<String>) -> Self {
+        Self {
+            inner,
+            cache: RwLock::new(None),
+            label: label.into(),
+        }
+    }
+
+    async fn get_or_refresh(&self) -> provider::Result {
+        let now = SystemTime::now();
+        {
+            let cache = self.cache.read().await;
+            if let Some(entry) = cache.as_ref() {
+                if entry.refresh_at.is_none_or(|refresh_at| now < refresh_at) {
+                    return Ok(entry.credentials.clone());
+                }
+            }
+        }
+
+        let mut cache = self.cache.write().await;
+        // Double-check: another task may have refreshed while we waited for the write lock.
+        let now = SystemTime::now();
+        if let Some(entry) = cache.as_ref() {
+            if entry.refresh_at.is_none_or(|refresh_at| now < refresh_at) {
+                return Ok(entry.credentials.clone());
+            }
+        }
+
+        match self.inner.provide_credentials().await {
+            Ok(credentials) => {
+                let now = SystemTime::now();
+                let expires_at = credentials.expiry();
+                let refresh_at = expires_at.map(|expires_at| {
+                    let validity = expires_at.duration_since(now).unwrap_or(Duration::ZERO);
+                    now + validity / 2
+                });
+                debug!(label = %self.label, ?expires_at, ?refresh_at, "aws credentials refreshed");
+                *cache = Some(CachedEntry {
+                    credentials: credentials.clone(),
+                    refresh_at,
+                    expires_at,
+                });
+                Ok(credentials)
+            }
+            Err(err) => {
+                if let Some(entry) = cache.as_ref() {
+                    if entry.expires_at.is_none_or(|expires_at| now < expires_at) {
+                        warn!(
+                            label = %self.label,
+                            error = %err,
+                            "failed to refresh aws credentials, serving stale cached credentials"
+                        );
+                        return Ok(entry.credentials.clone());
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+}
+
+impl ProvideCredentials for RefreshingCredentials {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(self.get_or_refresh())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_credential_types::provider::error::CredentialsError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex as AsyncMutex;
+
+    #[derive(Debug, Clone)]
+    enum FakeResponse {
+        Creds { validity: Option<Duration> },
+        Err,
+    }
+
+    #[derive(Debug)]
+    struct FakeProvider {
+        calls: AtomicUsize,
+        script: AsyncMutex<Vec<FakeResponse>>,
+    }
+
+    impl FakeProvider {
+        fn new(script: Vec<FakeResponse>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                script: AsyncMutex::new(script),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        async fn next(&self) -> provider::Result {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut script = self.script.lock().await;
+            let response = if script.len() > 1 {
+                script.remove(0)
+            } else {
+                script[0].clone()
+            };
+            match response {
+                FakeResponse::Creds { validity } => Ok(Credentials::new(
+                    "AKIDFAKE",
+                    "fake-secret",
+                    None,
+                    validity.map(|v| SystemTime::now() + v),
+                    "fake-provider",
+                )),
+                FakeResponse::Err => Err(CredentialsError::provider_error("fake failure")),
+            }
+        }
+    }
+
+    impl ProvideCredentials for FakeProvider {
+        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            future::ProvideCredentials::new(self.next())
+        }
+    }
+
+    #[tokio::test]
+    async fn caches_until_half_life_then_refreshes() {
+        let fake = Arc::new(FakeProvider::new(vec![FakeResponse::Creds {
+            validity: Some(Duration::from_millis(200)),
+        }]));
+        let cache = RefreshingCredentials::new(fake.clone(), "test");
+
+        cache.provide_credentials().await.unwrap();
+        assert_eq!(fake.call_count(), 1);
+
+        // well before half-life (100ms): still cached
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        cache.provide_credentials().await.unwrap();
+        assert_eq!(
+            fake.call_count(),
+            1,
+            "should still be serving cached credentials before half-life"
+        );
+
+        // past half-life: refreshes
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        cache.provide_credentials().await.unwrap();
+        assert_eq!(fake.call_count(), 2, "should refresh once past half-life");
+    }
+
+    #[tokio::test]
+    async fn no_expiry_is_cached_forever() {
+        let fake = Arc::new(FakeProvider::new(vec![FakeResponse::Creds {
+            validity: None,
+        }]));
+        let cache = RefreshingCredentials::new(fake.clone(), "test");
+
+        for _ in 0..5 {
+            cache.provide_credentials().await.unwrap();
+        }
+        assert_eq!(fake.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_refreshes_single_flight() {
+        let fake = Arc::new(FakeProvider::new(vec![FakeResponse::Creds {
+            validity: Some(Duration::from_millis(1)),
+        }]));
+        let cache = Arc::new(RefreshingCredentials::new(fake.clone(), "test"));
+
+        cache.provide_credentials().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await; // past half-life
+
+        let tasks: Vec<_> = (0..20)
+            .map(|_| {
+                let cache = cache.clone();
+                tokio::spawn(async move { cache.provide_credentials().await.unwrap() })
+            })
+            .collect();
+        for t in tasks {
+            t.await.unwrap();
+        }
+
+        assert_eq!(
+            fake.call_count(),
+            2,
+            "20 concurrent refreshers should collapse into a single real fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn serves_stale_credentials_when_refresh_fails() {
+        let fake = Arc::new(FakeProvider::new(vec![
+            FakeResponse::Creds {
+                validity: Some(Duration::from_millis(100)),
+            },
+            FakeResponse::Err,
+        ]));
+        let cache = RefreshingCredentials::new(fake.clone(), "test");
+
+        let first = cache.provide_credentials().await.unwrap();
+        // past half-life (50ms) but before real expiry (100ms)
+        tokio::time::sleep(Duration::from_millis(70)).await;
+        let second = cache.provide_credentials().await.unwrap();
+
+        assert_eq!(first.access_key_id(), second.access_key_id());
+        assert_eq!(
+            fake.call_count(),
+            2,
+            "a refresh attempt should have been made and failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_once_stale_credentials_truly_expire() {
+        let fake = Arc::new(FakeProvider::new(vec![
+            FakeResponse::Creds {
+                validity: Some(Duration::from_millis(30)),
+            },
+            FakeResponse::Err,
+        ]));
+        let cache = RefreshingCredentials::new(fake.clone(), "test");
+
+        cache.provide_credentials().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(60)).await; // past real expiry too
+        let result = cache.provide_credentials().await;
+
+        assert!(result.is_err());
+    }
+}

--- a/src/aws_auth/mod.rs
+++ b/src/aws_auth/mod.rs
@@ -1,0 +1,140 @@
+mod cache;
+mod signer;
+
+use crate::config::{listener::ListenerConfig, target::TargetConfig, AppConfig};
+use aws_config::{identity::IdentityCache, sts::AssumeRoleProvider, BehaviorVersion, SdkConfig};
+use aws_credential_types::provider::ProvideCredentials;
+use cache::RefreshingCredentials;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, LazyLock, RwLock},
+};
+use tokio::sync::OnceCell;
+use tracing::{debug, info};
+
+pub(crate) use signer::sign_request;
+
+static SDK_CONFIG: OnceCell<SdkConfig> = OnceCell::const_new();
+static CREDENTIALS: LazyLock<RwLock<HashMap<Option<String>, Arc<RefreshingCredentials>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+const STS_SESSION_NAME: &str = "http-dragonfly";
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum AwsAuthError {
+    #[error("failed to resolve AWS credentials for target `{target_id}`: {cause}")]
+    Credentials {
+        target_id: String,
+        cause: aws_credential_types::provider::error::CredentialsError,
+    },
+    #[error(
+        "no AWS region configured for target `{target_id}`: set `aws_sigv4.region` or the AWS SDK default region (AWS_REGION / profile)"
+    )]
+    NoRegion { target_id: String },
+}
+
+fn all_aws_sigv4_configs(
+    app_config: &AppConfig,
+) -> impl Iterator<Item = &crate::config::aws_sigv4::AwsSigV4Config> {
+    app_config
+        .listeners()
+        .iter()
+        .flat_map(ListenerConfig::targets)
+        .filter_map(TargetConfig::aws_sigv4)
+}
+
+pub(crate) fn is_signing_required(app_config: &AppConfig) -> bool {
+    all_aws_sigv4_configs(app_config).next().is_some()
+}
+
+/// Loads the AWS SDK default config and warms the shared credentials cache,
+/// but only if at least one target actually requires SigV4 signing.
+pub(crate) async fn init(app_config: &AppConfig) -> Result<(), AwsAuthError> {
+    if !is_signing_required(app_config) {
+        debug!("no target requires AWS SigV4 signing, skipping AWS SDK init");
+        return Ok(());
+    }
+
+    info!("initializing AWS SDK: at least one target requires SigV4 signing");
+    let sdk_config = SDK_CONFIG
+        .get_or_init(|| async {
+            aws_config::defaults(BehaviorVersion::latest())
+                .identity_cache(IdentityCache::no_cache())
+                .load()
+                .await
+        })
+        .await;
+
+    let has_default = all_aws_sigv4_configs(app_config).any(|c| c.role_arn().is_none());
+    let role_arns: HashSet<&str> = all_aws_sigv4_configs(app_config)
+        .filter_map(|c| c.role_arn())
+        .collect();
+
+    if has_default {
+        warm(None, sdk_config).await?;
+    }
+    for role_arn in role_arns {
+        warm(Some(role_arn), sdk_config).await?;
+    }
+
+    Ok(())
+}
+
+async fn warm(role_arn: Option<&str>, sdk_config: &SdkConfig) -> Result<(), AwsAuthError> {
+    let provider = provider_for(role_arn, sdk_config).await;
+    provider
+        .provide_credentials()
+        .await
+        .map_err(|cause| AwsAuthError::Credentials {
+            target_id: role_arn.unwrap_or("<default>").to_string(),
+            cause,
+        })?;
+    Ok(())
+}
+
+async fn provider_for(
+    role_arn: Option<&str>,
+    sdk_config: &SdkConfig,
+) -> Arc<RefreshingCredentials> {
+    let key = role_arn.map(str::to_string);
+
+    if let Some(provider) = CREDENTIALS
+        .read()
+        .expect("unable to lock credentials cache, looks like a BUG")
+        .get(&key)
+    {
+        return provider.clone();
+    }
+
+    // Build the provider without holding the lock, since building an
+    // AssumeRoleProvider requires an `.await` and the lock guard must not be
+    // held across it (it would make the caller's future non-Send).
+    let base = sdk_config
+        .credentials_provider()
+        .expect("AWS SDK always provides a default credentials provider chain, looks like a BUG");
+
+    let provider: Arc<RefreshingCredentials> = match role_arn {
+        None => Arc::new(RefreshingCredentials::new(Arc::new(base), "default")),
+        Some(role_arn) => {
+            let assume_role = AssumeRoleProvider::builder(role_arn)
+                .configure(sdk_config)
+                .session_name(STS_SESSION_NAME)
+                .build_from_provider(base)
+                .await;
+            Arc::new(RefreshingCredentials::new(
+                Arc::new(assume_role),
+                role_arn.to_string(),
+            ))
+        }
+    };
+
+    // Double-check: another task may have built and inserted the same key
+    // while we were building ours. Whichever inserted first wins; the loser
+    // is just a discarded (never-fetched-from) provider, not a wasted STS call.
+    CREDENTIALS
+        .write()
+        .expect("unable to lock credentials cache, looks like a BUG")
+        .entry(key)
+        .or_insert(provider)
+        .clone()
+}

--- a/src/aws_auth/signer.rs
+++ b/src/aws_auth/signer.rs
@@ -2,7 +2,7 @@ use super::{provider_for, AwsAuthError, SDK_CONFIG};
 use crate::config::aws_sigv4::AwsSigV4Config;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_sigv4::{
-    http_request::{sign, SignableBody, SignableRequest, SigningSettings},
+    http_request::{sign, PayloadChecksumKind, SignableBody, SignableRequest, SigningSettings},
     sign::v4,
 };
 use http_body_util::Full;
@@ -38,7 +38,13 @@ pub(crate) async fn sign_request(
             })?;
 
     let identity = credentials.into();
-    let signing_settings = SigningSettings::default();
+    let mut signing_settings = SigningSettings::default();
+    if aws_sigv4_cfg.service() == "s3" {
+        // S3 requires the `x-amz-content-sha256` header on every signed request;
+        // `NoHeader` (the crate default) omits it and S3 rejects the request with
+        // "Missing required header for this request: x-amz-content-sha256".
+        signing_settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+    }
     let signing_params: v4::SigningParams<SigningSettings> = v4::SigningParams::builder()
         .identity(&identity)
         .region(&region)
@@ -134,6 +140,71 @@ mod tests {
             .headers()
             .get(HeaderName::from_static("x-amz-date"))
             .is_some());
+    }
+
+    fn test_sdk_config() -> aws_config::SdkConfig {
+        aws_config::SdkConfig::builder()
+            .region(aws_config::Region::new("us-east-1"))
+            .credentials_provider(
+                aws_credential_types::provider::SharedCredentialsProvider::new(Credentials::new(
+                    "AKIDEXAMPLE",
+                    "secretkey",
+                    None,
+                    None,
+                    "test",
+                )),
+            )
+            .build()
+    }
+
+    #[tokio::test]
+    async fn s3_service_gets_content_sha256_header() {
+        // `SDK_CONFIG` is a process-wide `OnceCell`; ignore an already-set error so
+        // this test can run alongside `non_s3_service_omits_content_sha256_header`.
+        let _ = SDK_CONFIG.set(test_sdk_config());
+        let cfg: AwsSigV4Config = serde_yaml_ng::from_str("service: s3").unwrap();
+        let body = Bytes::from_static(b"hello world");
+        let mut request: Request<Full<Bytes>> = Request::builder()
+            .method("PUT")
+            .uri("https://examplebucket.s3.amazonaws.com/test.txt")
+            .header("host", "examplebucket.s3.amazonaws.com")
+            .body(Full::from(body.clone()))
+            .unwrap();
+
+        sign_request(&cfg, "test-target", &mut request, &body)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get(HeaderName::from_static("x-amz-content-sha256"))
+                .map(|v| v.to_str().unwrap()),
+            // sha256("hello world")
+            Some("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_s3_service_omits_content_sha256_header() {
+        let _ = SDK_CONFIG.set(test_sdk_config());
+        let cfg: AwsSigV4Config = serde_yaml_ng::from_str("service: execute-api").unwrap();
+        let body = Bytes::from_static(b"hello world");
+        let mut request: Request<Full<Bytes>> = Request::builder()
+            .method("GET")
+            .uri("https://abc123.execute-api.us-east-1.amazonaws.com/prod/")
+            .header("host", "abc123.execute-api.us-east-1.amazonaws.com")
+            .body(Full::from(body.clone()))
+            .unwrap();
+
+        sign_request(&cfg, "test-target", &mut request, &body)
+            .await
+            .unwrap();
+
+        assert!(request
+            .headers()
+            .get(HeaderName::from_static("x-amz-content-sha256"))
+            .is_none());
     }
 
     #[test]

--- a/src/aws_auth/signer.rs
+++ b/src/aws_auth/signer.rs
@@ -1,0 +1,190 @@
+use super::{provider_for, AwsAuthError, SDK_CONFIG};
+use crate::config::aws_sigv4::AwsSigV4Config;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::{
+    http_request::{sign, SignableBody, SignableRequest, SigningSettings},
+    sign::v4,
+};
+use http_body_util::Full;
+use hyper::{body::Bytes, Request};
+use std::time::SystemTime;
+
+pub(crate) async fn sign_request(
+    aws_sigv4_cfg: &AwsSigV4Config,
+    target_id: &str,
+    request: &mut Request<Full<Bytes>>,
+    body: &Bytes,
+) -> Result<(), AwsAuthError> {
+    let sdk_config = SDK_CONFIG
+        .get()
+        .expect("AWS SDK must be initialized before signing a request, looks like a BUG");
+
+    let region = aws_sigv4_cfg
+        .region()
+        .map(str::to_string)
+        .or_else(|| sdk_config.region().map(|r| r.to_string()))
+        .ok_or_else(|| AwsAuthError::NoRegion {
+            target_id: target_id.to_string(),
+        })?;
+
+    let provider = provider_for(aws_sigv4_cfg.role_arn(), sdk_config).await;
+    let credentials =
+        provider
+            .provide_credentials()
+            .await
+            .map_err(|cause| AwsAuthError::Credentials {
+                target_id: target_id.to_string(),
+                cause,
+            })?;
+
+    let identity = credentials.into();
+    let signing_settings = SigningSettings::default();
+    let signing_params: v4::SigningParams<SigningSettings> = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(&region)
+        .name(aws_sigv4_cfg.service())
+        .time(SystemTime::now())
+        .settings(signing_settings)
+        .build()
+        .expect("all required SigV4 signing parameters are provided, looks like a BUG");
+    let signing_params = signing_params.into();
+
+    let headers: Vec<(&str, &str)> = request
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| value.to_str().ok().map(|v| (name.as_str(), v)))
+        .collect();
+
+    let signable_request = SignableRequest::new(
+        request.method().as_str(),
+        request.uri().to_string(),
+        headers.into_iter(),
+        SignableBody::Bytes(body),
+    )
+    .expect(
+        "method/uri/headers are always valid ASCII for an already-built request, looks like a BUG",
+    );
+
+    let (signing_instructions, _signature) = sign(signable_request, &signing_params)
+        .expect("signing a well-formed request cannot fail, looks like a BUG")
+        .into_parts();
+    signing_instructions.apply_to_request_http1x(request);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_credential_types::Credentials;
+    use hyper::header::HeaderName;
+
+    #[test]
+    fn signing_matches_independently_computed_signature() {
+        let credentials = Credentials::new("AKIDEXAMPLE", "secretkey", None, None, "test");
+        let time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_440_938_160); // 2015-08-30T12:16:00Z
+        let body = Bytes::from_static(b"hello world");
+
+        let mut request: Request<Full<Bytes>> = Request::builder()
+            .method("PUT")
+            .uri("https://examplebucket.s3.amazonaws.com/test.txt")
+            .header("host", "examplebucket.s3.amazonaws.com")
+            .body(Full::from(body.clone()))
+            .unwrap();
+
+        // "Actual": build signing params/instructions the exact same way sign_request() does.
+        let identity = credentials.clone().into();
+        let signing_params: v4::SigningParams<SigningSettings> = v4::SigningParams::builder()
+            .identity(&identity)
+            .region("us-east-1")
+            .name("s3")
+            .time(time)
+            .settings(SigningSettings::default())
+            .build()
+            .unwrap();
+        let signing_params = signing_params.into();
+        let headers: Vec<(&str, &str)> = request
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.to_str().unwrap()))
+            .collect();
+        let signable_request = SignableRequest::new(
+            request.method().as_str(),
+            request.uri().to_string(),
+            headers.into_iter(),
+            SignableBody::Bytes(&body),
+        )
+        .unwrap();
+        let (instructions, expected_signature) = sign(signable_request, &signing_params)
+            .unwrap()
+            .into_parts();
+        instructions.apply_to_request_http1x(&mut request);
+
+        let auth_header = request
+            .headers()
+            .get(HeaderName::from_static("authorization"))
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(auth_header.contains(&expected_signature));
+        assert!(auth_header.starts_with(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/s3/aws4_request"
+        ));
+        assert!(request
+            .headers()
+            .get(HeaderName::from_static("x-amz-date"))
+            .is_some());
+    }
+
+    #[test]
+    fn session_token_is_included_when_present() {
+        let credentials = Credentials::new(
+            "AKIDEXAMPLE",
+            "secretkey",
+            Some("sessiontoken".to_string()),
+            None,
+            "test",
+        );
+        let identity = credentials.into();
+        let signing_params: v4::SigningParams<SigningSettings> = v4::SigningParams::builder()
+            .identity(&identity)
+            .region("us-east-1")
+            .name("s3")
+            .time(SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .unwrap();
+        let signing_params = signing_params.into();
+        let body = Bytes::new();
+        let mut request: Request<Full<Bytes>> = Request::builder()
+            .method("GET")
+            .uri("https://examplebucket.s3.amazonaws.com/")
+            .header("host", "examplebucket.s3.amazonaws.com")
+            .body(Full::from(body.clone()))
+            .unwrap();
+        let headers: Vec<(&str, &str)> = request
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.to_str().unwrap()))
+            .collect();
+        let signable_request = SignableRequest::new(
+            request.method().as_str(),
+            request.uri().to_string(),
+            headers.into_iter(),
+            SignableBody::Bytes(&body),
+        )
+        .unwrap();
+        let (instructions, _sig) = sign(signable_request, &signing_params)
+            .unwrap()
+            .into_parts();
+        instructions.apply_to_request_http1x(&mut request);
+
+        assert_eq!(
+            request
+                .headers()
+                .get(HeaderName::from_static("x-amz-security-token"))
+                .map(|v| v.to_str().unwrap()),
+            Some("sessiontoken")
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+pub mod aws_sigv4;
 pub mod headers;
 pub mod listener;
 pub mod response;

--- a/src/config/aws_sigv4.rs
+++ b/src/config/aws_sigv4.rs
@@ -1,0 +1,94 @@
+use super::ConfigValidator;
+use crate::config::ConfigError;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AwsSigV4Config {
+    service: String,
+    region: Option<String>,
+    role_arn: Option<String>,
+}
+
+impl AwsSigV4Config {
+    pub fn service(&self) -> &str {
+        &self.service
+    }
+
+    pub fn region(&self) -> Option<&str> {
+        self.region.as_deref()
+    }
+
+    pub fn role_arn(&self) -> Option<&str> {
+        self.role_arn.as_deref()
+    }
+}
+
+impl ConfigValidator for AwsSigV4Config {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.service.trim().is_empty() {
+            return Err(ConfigError::ValidateConfig {
+                cause: "`aws_sigv4.service` must not be empty".into(),
+            });
+        }
+        if let Some(role_arn) = &self.role_arn {
+            if !role_arn.starts_with("arn:") || !role_arn.contains(":role/") {
+                return Err(ConfigError::ValidateConfig {
+                    cause: format!(
+                        "`aws_sigv4.role_arn` doesn't look like a valid IAM role ARN: `{role_arn}`"
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal() {
+        let cfg: AwsSigV4Config = serde_yaml_ng::from_str("service: s3").unwrap();
+        assert_eq!(cfg.service(), "s3");
+        assert_eq!(cfg.region(), None);
+        assert_eq!(cfg.role_arn(), None);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn parses_full() {
+        let cfg: AwsSigV4Config = serde_yaml_ng::from_str(
+            "service: execute-api\nregion: eu-west-1\nrole_arn: arn:aws:iam::123456789012:role/my-role",
+        )
+        .unwrap();
+        assert_eq!(cfg.service(), "execute-api");
+        assert_eq!(cfg.region(), Some("eu-west-1"));
+        assert_eq!(
+            cfg.role_arn(),
+            Some("arn:aws:iam::123456789012:role/my-role")
+        );
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_service() {
+        let cfg: AwsSigV4Config = serde_yaml_ng::from_str("service: \"\"").unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_bad_role_arn() {
+        let cfg: AwsSigV4Config =
+            serde_yaml_ng::from_str("service: s3\nrole_arn: not-an-arn").unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let result: Result<AwsSigV4Config, _> =
+            serde_yaml_ng::from_str("service: s3\naccess_key: AKIA...");
+        assert!(result.is_err());
+    }
+}

--- a/src/config/response.rs
+++ b/src/config/response.rs
@@ -210,6 +210,7 @@ impl ResponseBehavior for ResponseConfig {
                     }
                 }
                 ResponseResult::Timeout => resp.status(StatusCode::GATEWAY_TIMEOUT),
+                ResponseResult::SigningError(_) => resp.status(StatusCode::INTERNAL_SERVER_ERROR),
                 _ => {
                     panic!("Looks like a BUG!")
                 }

--- a/src/config/snapshots/http_dragonfly__config__headers__tests__transforms.snap
+++ b/src/config/snapshots/http_dragonfly__config__headers__tests__transforms.snap
@@ -5,7 +5,7 @@ expression: ctx
 Context(
   own: {
     "CTX_APP_NAME": "http-dragonfly",
-    "CTX_APP_VERSION": "0.4.5",
+    "CTX_APP_VERSION": "0.5.0",
     "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
     "TEST_ENV_KEY": "TEST_ENV_VALUE",
   },

--- a/src/config/target.rs
+++ b/src/config/target.rs
@@ -1,4 +1,5 @@
 use super::{
+    aws_sigv4::AwsSigV4Config,
     headers::HeaderTransform,
     listener::{TlsConfig, TlsVerifyConfig},
     response::ResponseStatus,
@@ -7,7 +8,7 @@ use super::{
 use crate::{config::ConfigError, context::Context};
 use core::fmt;
 use http_body_util::Full;
-use hyper::{body::Bytes, http::request::Parts, Uri};
+use hyper::{body::Bytes, http::request::Parts, Request, Uri};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{
     client::legacy::{connect::HttpConnector, Client},
@@ -58,6 +59,7 @@ pub struct TargetConfig {
     condition: Option<TargetConditionConfig>,
     #[serde(default)]
     tls: Option<TlsConfig>,
+    aws_sigv4: Option<AwsSigV4Config>,
 }
 
 impl TargetConfig {
@@ -113,6 +115,23 @@ impl TargetConfig {
 
     pub fn condition(&self) -> &Option<TargetConditionConfig> {
         &self.condition
+    }
+
+    pub fn aws_sigv4(&self) -> Option<&AwsSigV4Config> {
+        self.aws_sigv4.as_ref()
+    }
+
+    /// Signs the request with AWS SigV4 if this target has `aws_sigv4` configured.
+    /// No-op if it doesn't.
+    pub(crate) async fn sign_request(
+        &self,
+        request: &mut Request<Full<Bytes>>,
+        body: &Bytes,
+    ) -> Result<(), crate::aws_auth::AwsAuthError> {
+        if let Some(aws_sigv4_cfg) = self.aws_sigv4() {
+            crate::aws_auth::sign_request(aws_sigv4_cfg, &self.id(), request, body).await?;
+        }
+        Ok(())
     }
 
     /// Returns http client with configured (or default) tls config and timeout
@@ -447,6 +466,10 @@ impl ConfigValidator for TargetConfig {
             }
         }
 
+        if let Some(aws_sigv4) = self.aws_sigv4() {
+            aws_sigv4.validate()?;
+        }
+
         Ok(())
     }
 }
@@ -539,6 +562,7 @@ pub mod test_target {
             error_status: None,
             condition: Some(TargetConditionConfig::Default),
             tls: Default::default(),
+            aws_sigv4: None,
         }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     context::Context,
 };
-use futures_util::future::join_all;
 use http::HeaderValue;
 use http_body_util::{BodyExt, Full};
 use hyper::{
@@ -22,6 +21,15 @@ use uuid::Uuid;
 
 pub type ResponsesMap<'a> = HashMap<String, (Option<Response<Full<Bytes>>>, &'a Context<'a>)>;
 pub type HyperError = hyper_util::client::legacy::Error;
+
+enum TargetDispatch {
+    Spawned(
+        tokio::task::JoinHandle<
+            Result<Result<Response<Incoming>, HyperError>, tokio::time::error::Elapsed>,
+        >,
+    ),
+    SigningFailed(String),
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct RequestHandler {
@@ -186,46 +194,65 @@ impl RequestHandler {
                 target_request_builder = target_request_builder.header(k, v);
             }
             // Finalize request with body
-            let target_request: Request<Full<Bytes>> = if let Some(body) = &target.body() {
+            let target_body: Bytes = if let Some(body) = &target.body() {
                 let body = env_with_context_no_errors(body, |v| ctx.get(&v.into()));
-                target_request_builder.body(Full::from(body))?
+                Bytes::from(body.into_owned().into_bytes())
             } else {
-                target_request_builder.body(Full::from(body_bytes.clone()))?
+                body_bytes.clone()
             };
+            let mut target_request: Request<Full<Bytes>> =
+                target_request_builder.body(Full::from(target_body.clone()))?;
 
-            // Put request to queue
-            debug!(
-                "add to queue: target `{}` request: {:?}",
-                target.id(),
-                target_request
-            );
+            // Sign the request if this target requires AWS SigV4
+            let signing_result = target.sign_request(&mut target_request, &target_body).await;
 
-            // Prepare target request
-            let http_client = target.https_client(self.listener_cfg.tls());
-            let http_request = http_client.request(target_request);
-            let http_request = tokio::time::timeout(*target.timeout(), http_request);
+            match signing_result {
+                Ok(()) => {
+                    // Put request to queue
+                    debug!(
+                        "add to queue: target `{}` request: {:?}",
+                        target.id(),
+                        target_request
+                    );
 
-            target_requests.push(tokio::spawn(http_request));
+                    // Prepare target request
+                    let http_client = target.https_client(self.listener_cfg.tls());
+                    let http_request = http_client.request(target_request);
+                    let http_request = tokio::time::timeout(*target.timeout(), http_request);
+
+                    target_requests.push(TargetDispatch::Spawned(tokio::spawn(http_request)));
+                }
+                Err(e) => {
+                    error!(
+                        "{req_id}: target `{}` signing failed, listener: {}: {e}",
+                        target.id(),
+                        self.listener_cfg.id()
+                    );
+                    target_requests.push(TargetDispatch::SigningFailed(e.to_string()));
+                }
+            }
             target_ctx.push(ctx);
             target_ids.push(target.id());
         }
 
         // Get results
-        let raw_results = join_all(target_requests).await;
         let mut results: Vec<ResponseResult> = vec![];
-        for r in raw_results.into_iter().map(|r| r.unwrap()) {
-            let r = match r {
-                Err(_ee) => ResponseResult::Timeout,
-                Ok(r) => match r {
-                    Ok(r) => {
-                        // Prepare owned body
-                        let (parts, body) = r.into_parts();
-                        let body = body.collect().await.expect("Looks like a BUG!").to_bytes();
-                        let r: Response<Full<Bytes>> =
-                            Response::from_parts(parts, Full::from(body));
-                        ResponseResult::Ok(r)
-                    }
-                    Err(he) => ResponseResult::HyperError(he),
+        for dispatch in target_requests {
+            let r = match dispatch {
+                TargetDispatch::SigningFailed(cause) => ResponseResult::SigningError(cause),
+                TargetDispatch::Spawned(handle) => match handle.await.unwrap() {
+                    Err(_ee) => ResponseResult::Timeout,
+                    Ok(r) => match r {
+                        Ok(r) => {
+                            // Prepare owned body
+                            let (parts, body) = r.into_parts();
+                            let body = body.collect().await.expect("Looks like a BUG!").to_bytes();
+                            let r: Response<Full<Bytes>> =
+                                Response::from_parts(parts, Full::from(body));
+                            ResponseResult::Ok(r)
+                        }
+                        Err(he) => ResponseResult::HyperError(he),
+                    },
                 },
             };
             results.push(r);
@@ -239,6 +266,7 @@ impl RequestHandler {
                     ResponseResult::Ok(response) => format!("ok {}", response.status().as_u16()),
                     ResponseResult::HyperError(error) => format!("error: {}", error),
                     ResponseResult::Timeout => "timeout".to_string(),
+                    ResponseResult::SigningError(cause) => format!("aws signing error: {cause}"),
                 };
                 info!(
                     "{req_id}: listener: {}, target `{}`, status: {}",
@@ -252,7 +280,9 @@ impl RequestHandler {
                     debug!("OK response: {:#?}", resp);
                     responses.insert(target_ids[pos].clone(), (Some(resp), &target_ctx[pos]));
                 }
-                ResponseResult::HyperError(_) | ResponseResult::Timeout => {
+                ResponseResult::HyperError(_)
+                | ResponseResult::Timeout
+                | ResponseResult::SigningError(_) => {
                     debug!("ERR response: {:#?}", res);
                     let target = targets[pos];
                     let resp = match target.on_error() {
@@ -328,4 +358,5 @@ pub enum ResponseResult {
     Ok(Response<Full<Bytes>>),
     HyperError(HyperError),
     Timeout,
+    SigningError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod context;
 pub mod signal;
 
+mod aws_auth;
 mod handler;
 mod health_check;
 
@@ -36,6 +37,7 @@ pub async fn run(
 
     let root_ctx = Arc::new(Context::root(env_provider));
     let app_config = AppConfig::new(cli_config.config_path(), *root_ctx)?;
+    aws_auth::init(app_config).await?;
     let mut servers: Vec<HyperTaskJoinHandle> = vec![];
 
     for cfg in app_config.listeners().iter().map(Arc::new) {

--- a/src/snapshots/http_dragonfly__config__test__good_config@01-minimal.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@01-minimal.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@02-simple-config.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@02-simple-config.yaml.snap
@@ -70,6 +70,7 @@ Ok(
                         ),
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -89,6 +90,7 @@ Ok(
                             ),
                         ),
                         tls: None,
+                        aws_sigv4: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -119,6 +121,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,
@@ -151,7 +154,7 @@ Ok(
                                             "X-Http-Splitter-Version",
                                         ),
                                         value: Some(
-                                            "0.4.5",
+                                            "0.5.0",
                                         ),
                                     },
                                     HeaderTransform {

--- a/src/snapshots/http_dragonfly__config__test__good_config@10-strategy-always_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@10-strategy-always_override.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@20-strategy-always_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@20-strategy-always_target_id.yaml.snap
@@ -29,6 +29,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@30-strategy-ok_then_failed.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@30-strategy-ok_then_failed.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@40-strategy-ok_then_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@40-strategy-ok_then_target_id.yaml.snap
@@ -29,6 +29,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@50-strategy-ok_then_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@50-strategy-ok_then_override.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@60-strategy-failed_then_ok.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@60-strategy-failed_then_ok.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@70-strategy-failed_then_target_id.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@70-strategy-failed_then_target_id.yaml.snap
@@ -29,6 +29,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@80-strategy-failed_then_override.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@80-strategy-failed_then_override.yaml.snap
@@ -27,6 +27,7 @@ Ok(
                         error_status: None,
                         condition: None,
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@90-strategy-conditional_routing.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@90-strategy-conditional_routing.yaml.snap
@@ -31,6 +31,7 @@ Ok(
                             Default,
                         ),
                         tls: None,
+                        aws_sigv4: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -50,6 +51,7 @@ Ok(
                             ),
                         ),
                         tls: None,
+                        aws_sigv4: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -69,6 +71,7 @@ Ok(
                             ),
                         ),
                         tls: None,
+                        aws_sigv4: None,
                     },
                     TargetConfig {
                         id: Some(
@@ -88,6 +91,7 @@ Ok(
                             ),
                         ),
                         tls: None,
+                        aws_sigv4: None,
                     },
                 ],
                 log_target_status: false,

--- a/src/snapshots/http_dragonfly__config__test__good_config@95-aws-sigv4.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__good_config@95-aws-sigv4.yaml.snap
@@ -1,0 +1,75 @@
+---
+source: src/config.rs
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
+input_file: tests/configs/good/95-aws-sigv4.yaml
+---
+Ok(
+    AppConfig {
+        listeners: [
+            ListenerConfig {
+                id: None,
+                listen_on: ListenOn {
+                    ip: 0.0.0.0,
+                    port: 8080,
+                },
+                timeout: 10s,
+                strategy: FailedThenOverride,
+                headers: None,
+                methods: None,
+                targets: [
+                    TargetConfig {
+                        id: None,
+                        url: "https://my-bucket.s3.us-east-1.amazonaws.com/key",
+                        headers: None,
+                        body: None,
+                        timeout: 60s,
+                        on_error: Propagate,
+                        error_status: None,
+                        condition: None,
+                        tls: None,
+                        aws_sigv4: Some(
+                            AwsSigV4Config {
+                                service: "s3",
+                                region: None,
+                                role_arn: None,
+                            },
+                        ),
+                    },
+                    TargetConfig {
+                        id: None,
+                        url: "https://search-my-domain.us-west-2.es.amazonaws.com/_search",
+                        headers: None,
+                        body: None,
+                        timeout: 60s,
+                        on_error: Propagate,
+                        error_status: None,
+                        condition: None,
+                        tls: None,
+                        aws_sigv4: Some(
+                            AwsSigV4Config {
+                                service: "es",
+                                region: Some(
+                                    "us-west-2",
+                                ),
+                                role_arn: Some(
+                                    "arn:aws:iam::123456789012:role/my-role",
+                                ),
+                            },
+                        ),
+                    },
+                ],
+                log_target_status: false,
+                response: ResponseConfig {
+                    target_selector: None,
+                    failed_status_regex: "4\\d{2}|5\\d{2}",
+                    no_targets_status: 500,
+                    override_config: None,
+                },
+                tls: TlsConfig {
+                    verify: Yes,
+                    ca: None,
+                },
+            },
+        ],
+    },
+)

--- a/src/snapshots/http_dragonfly__config__test__wrong_config@95-aws-sigv4-bad-service.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__wrong_config@95-aws-sigv4-bad-service.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: src/config.rs
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
+input_file: tests/configs/wrong/95-aws-sigv4-bad-service.yaml
+---
+Err(
+    invalid config: `aws_sigv4.service` must not be empty,
+)

--- a/src/snapshots/http_dragonfly__config__test__wrong_config@96-aws-sigv4-bad-role-arn.yaml.snap
+++ b/src/snapshots/http_dragonfly__config__test__wrong_config@96-aws-sigv4-bad-role-arn.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: src/config.rs
+expression: "AppConfig::from_file(&String::from(path.to_str().unwrap()), ctx)"
+input_file: tests/configs/wrong/96-aws-sigv4-bad-role-arn.yaml
+---
+Err(
+    invalid config: `aws_sigv4.role_arn` doesn't look like a valid IAM role ARN: `not-an-arn`,
+)

--- a/src/snapshots/http_dragonfly__context__test_context__context_with.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__context_with.snap
@@ -9,7 +9,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.4.5",
+      "CTX_APP_VERSION": "0.5.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__context_with_test_environment.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__context_with_test_environment.snap
@@ -5,7 +5,7 @@ expression: get_test_ctx()
 Context(
   own: {
     "CTX_APP_NAME": "http-dragonfly",
-    "CTX_APP_VERSION": "0.4.5",
+    "CTX_APP_VERSION": "0.5.0",
     "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
     "TEST_ENV_KEY": "TEST_ENV_VALUE",
   },

--- a/src/snapshots/http_dragonfly__context__test_context__request_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__request_context.snap
@@ -15,7 +15,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.4.5",
+      "CTX_APP_VERSION": "0.5.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__response_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__response_context.snap
@@ -10,7 +10,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.4.5",
+      "CTX_APP_VERSION": "0.5.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/src/snapshots/http_dragonfly__context__test_context__target_context.snap
+++ b/src/snapshots/http_dragonfly__context__test_context__target_context.snap
@@ -10,7 +10,7 @@ Context(
   parent: Some(Context(
     own: {
       "CTX_APP_NAME": "http-dragonfly",
-      "CTX_APP_VERSION": "0.4.5",
+      "CTX_APP_VERSION": "0.5.0",
       "TEST_ENV_HEADER_TO_ADD": "TEST_ENV_HEADER_VALUE",
       "TEST_ENV_KEY": "TEST_ENV_VALUE",
     },

--- a/tests/aws_sigv4.rs
+++ b/tests/aws_sigv4.rs
@@ -1,0 +1,133 @@
+use http_dragonfly::{cli::CliConfig, context::RootOsEnvironment};
+use reqwest::Client;
+use std::time::Duration;
+use testcontainers_modules::{
+    localstack::LocalStack,
+    testcontainers::{runners::AsyncRunner, ImageExt},
+};
+
+const TEST_CONFIG_PATH: &str = "tests/configs/integration/aws-sigv4.yaml";
+const BUCKET: &str = "http-dragonfly-test-bucket";
+
+#[tokio::test]
+async fn signs_requests_to_localstack_s3() {
+    let container = LocalStack::default()
+        .with_env_var("SERVICES", "s3,sts,iam")
+        .start()
+        .await
+        .expect("failed to start localstack container, is Docker running?");
+    let ls_port = container
+        .get_host_port_ipv4(4566)
+        .await
+        .expect("failed to get localstack mapped port");
+
+    // SAFETY: this test file has a single test function, so there's no other task
+    // in this process racing these env var writes.
+    unsafe {
+        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+        std::env::set_var("AWS_REGION", "us-east-1");
+        std::env::set_var("AWS_ENDPOINT_URL", format!("http://127.0.0.1:{ls_port}"));
+        std::env::set_var("TEST_HTTP_ENV_LOCALSTACK_PORT", ls_port.to_string());
+    }
+
+    let cli_config = CliConfig::from_config_path(TEST_CONFIG_PATH.into());
+    let env_provider = RootOsEnvironment::new("^TEST_HTTP_ENV_[A-Z0-9_]+$");
+    let server = http_dragonfly::run(cli_config, env_provider);
+    let timer = tokio::time::sleep(Duration::from_secs(120));
+
+    let test = async {
+        let client = Client::new();
+
+        // `run()` does async AWS SDK init (and, for the assumed-role listener, a real
+        // STS AssumeRole call) before it binds any listener, so wait for each port to
+        // actually accept connections instead of assuming it's instantly up.
+        for port in [9101, 9102] {
+            wait_for_listener(port, Duration::from_secs(60)).await;
+        }
+
+        // Create the bucket via the default-credentials-signed listener.
+        let resp = client
+            .put(format!("http://localhost:9101/{BUCKET}/"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "create bucket failed: {}",
+            resp.status()
+        );
+
+        // PUT + GET an object signed with default (env) credentials.
+        let resp = client
+            .put(format!("http://localhost:9101/{BUCKET}/hello.txt"))
+            .body("hello from default creds")
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "put object failed: {}",
+            resp.status()
+        );
+
+        let resp = client
+            .get(format!("http://localhost:9101/{BUCKET}/hello.txt"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "get object failed: {}",
+            resp.status()
+        );
+        assert_eq!(resp.text().await.unwrap(), "hello from default creds");
+
+        // PUT + GET an object signed via an assumed role.
+        let resp = client
+            .put(format!("http://localhost:9102/{BUCKET}/hello-role.txt"))
+            .body("hello via assumed role")
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "put object via assumed role failed: {}",
+            resp.status()
+        );
+
+        let resp = client
+            .get(format!("http://localhost:9102/{BUCKET}/hello-role.txt"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "get object via assumed role failed: {}",
+            resp.status()
+        );
+        assert_eq!(resp.text().await.unwrap(), "hello via assumed role");
+    };
+
+    tokio::select! {
+        _ = server => panic!("http-dragonfly server crashed"),
+        _ = timer => panic!("test timed out"),
+        _ = test => {}
+    }
+}
+
+async fn wait_for_listener(port: u16, deadline: Duration) {
+    let start = tokio::time::Instant::now();
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        if start.elapsed() > deadline {
+            panic!("listener on port {port} did not become ready within {deadline:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/tests/configs/good/95-aws-sigv4.yaml
+++ b/tests/configs/good/95-aws-sigv4.yaml
@@ -1,0 +1,10 @@
+listeners:
+  - targets:
+      - url: https://my-bucket.s3.us-east-1.amazonaws.com/key
+        aws_sigv4:
+          service: s3
+      - url: https://search-my-domain.us-west-2.es.amazonaws.com/_search
+        aws_sigv4:
+          service: es
+          region: us-west-2
+          role_arn: arn:aws:iam::123456789012:role/my-role

--- a/tests/configs/integration/aws-sigv4.yaml
+++ b/tests/configs/integration/aws-sigv4.yaml
@@ -1,0 +1,31 @@
+# Requires a localstack container; port is substituted via the
+# TEST_HTTP_ENV_LOCALSTACK_PORT env var set by tests/aws_sigv4.rs.
+#
+# Two listeners: one signs with the default (env) AWS credentials, the other
+# signs via an assumed IAM role, proving both credential paths work end to end.
+
+listeners:
+  - id: aws-sigv4-default-creds
+    listen_on: "*:9101"
+    strategy: always_target_id
+    targets:
+      - id: s3
+        url: http://127.0.0.1:${TEST_HTTP_ENV_LOCALSTACK_PORT}/${CTX_REQUEST_PATH}
+        aws_sigv4:
+          service: s3
+          region: us-east-1
+    response:
+      target_selector: s3
+
+  - id: aws-sigv4-assumed-role
+    listen_on: "*:9102"
+    strategy: always_target_id
+    targets:
+      - id: s3
+        url: http://127.0.0.1:${TEST_HTTP_ENV_LOCALSTACK_PORT}/${CTX_REQUEST_PATH}
+        aws_sigv4:
+          service: s3
+          region: us-east-1
+          role_arn: arn:aws:iam::000000000000:role/http-dragonfly-test-role
+    response:
+      target_selector: s3

--- a/tests/configs/integration/tls.yaml
+++ b/tests/configs/integration/tls.yaml
@@ -1,4 +1,8 @@
 # Requires TLS echo server on port 3001
+#
+# `ca:` paths below use the literal placeholder `tests/tls/`, rewritten by
+# tests/tls.rs to the current build's OUT_DIR (where the CA bundle is actually
+# generated) before this file is loaded -- see resolve_test_config_path().
 
 # 9000 - fails due to unknown cert
 # 9001 - disabled tls verification

--- a/tests/configs/wrong/95-aws-sigv4-bad-service.yaml
+++ b/tests/configs/wrong/95-aws-sigv4-bad-service.yaml
@@ -1,0 +1,5 @@
+listeners:
+  - targets:
+      - url: https://example.com/
+        aws_sigv4:
+          service: ""

--- a/tests/configs/wrong/96-aws-sigv4-bad-role-arn.yaml
+++ b/tests/configs/wrong/96-aws-sigv4-bad-role-arn.yaml
@@ -1,0 +1,6 @@
+listeners:
+  - targets:
+      - url: https://example.com/
+        aws_sigv4:
+          service: s3
+          role_arn: not-an-arn

--- a/tests/scripts/create-test-certificates.sh
+++ b/tests/scripts/create-test-certificates.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # 1 - files prefix
 #     may include path to destination folder
@@ -28,5 +29,29 @@ cat ${prefix}end.crt ${prefix}inter.crt > ${prefix}test-server.pem
 cat ${prefix}inter.crt ${prefix}ca.crt > ${prefix}ca.pem
 rm ${prefix}*.req ${prefix}ca.key ${prefix}inter.key ${prefix}end.key
 
-mkdir tests/tls
+# tests/tls/ is a fixed path shared by every build.rs invocation (test fixtures
+# reference it directly, so it can't be scoped to this run's OUT_DIR). Without
+# coordination, concurrent invocations of this script -- e.g. an IDE's
+# background `cargo check` racing a terminal `cargo test` -- can interleave
+# their mkdir/cp here and leave tests/tls/ empty or holding a CA/server-cert
+# pair from two different runs, which then fails TLS handshakes. Serialize the
+# publish step with a portable mkdir-based lock; if it's still held after 15s
+# (should never happen, the critical section is a couple of file copies),
+# proceed anyway rather than deadlock.
+lock_dir="tests/.tls.lock"
+lock_acquired=0
+attempt=0
+while [ "${attempt}" -lt 150 ]; do
+    if mkdir "${lock_dir}" 2>/dev/null; then
+        lock_acquired=1
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.1
+done
+if [ "${lock_acquired}" -eq 1 ]; then
+    trap 'rmdir "${lock_dir}" 2>/dev/null || true' EXIT INT TERM
+fi
+
+mkdir -p tests/tls
 cp ${prefix}ca.* tests/tls/

--- a/tests/scripts/create-test-certificates.sh
+++ b/tests/scripts/create-test-certificates.sh
@@ -29,29 +29,9 @@ cat ${prefix}end.crt ${prefix}inter.crt > ${prefix}test-server.pem
 cat ${prefix}inter.crt ${prefix}ca.crt > ${prefix}ca.pem
 rm ${prefix}*.req ${prefix}ca.key ${prefix}inter.key ${prefix}end.key
 
-# tests/tls/ is a fixed path shared by every build.rs invocation (test fixtures
-# reference it directly, so it can't be scoped to this run's OUT_DIR). Without
-# coordination, concurrent invocations of this script -- e.g. an IDE's
-# background `cargo check` racing a terminal `cargo test` -- can interleave
-# their mkdir/cp here and leave tests/tls/ empty or holding a CA/server-cert
-# pair from two different runs, which then fails TLS handshakes. Serialize the
-# publish step with a portable mkdir-based lock; if it's still held after 15s
-# (should never happen, the critical section is a couple of file copies),
-# proceed anyway rather than deadlock.
-lock_dir="tests/.tls.lock"
-lock_acquired=0
-attempt=0
-while [ "${attempt}" -lt 150 ]; do
-    if mkdir "${lock_dir}" 2>/dev/null; then
-        lock_acquired=1
-        break
-    fi
-    attempt=$((attempt + 1))
-    sleep 0.1
-done
-if [ "${lock_acquired}" -eq 1 ]; then
-    trap 'rmdir "${lock_dir}" 2>/dev/null || true' EXIT INT TERM
-fi
-
-mkdir -p tests/tls
-cp ${prefix}ca.* tests/tls/
+# Everything lives under $prefix (== OUT_DIR/), which Cargo gives a fresh,
+# uniquely-hashed directory per build -- never shared with any other,
+# independent cargo invocation (e.g. an IDE's background `cargo check`). Tests
+# read these files straight from OUT_DIR (see tests/common/mod.rs and
+# tests/tls.rs) instead of a shared, mutable path, so there's nothing left to
+# publish here and nothing for concurrent builds to race on.

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -3,9 +3,27 @@ mod common;
 use crate::common::run_test_with_config;
 use common::{init_logging, test_one_case, TestConfig};
 use futures_util::future::join_all;
+use std::{env, fs};
 
-const TEST_CONFIG_PATH: &str = "tests/configs/integration/tls.yaml";
+const TEST_CONFIG_TEMPLATE: &str = "tests/configs/integration/tls.yaml";
 const TEST_PORT: u16 = 3001;
+
+/// The template's `ca:` paths point at the literal string `tests/tls/`, which this
+/// resolves to the current build's `OUT_DIR` and writes out as a real config file.
+/// `OUT_DIR` is where `create-test-certificates.sh` actually writes the CA bundle
+/// (see build.rs), and it's unique per build -- unlike a shared, mutable path, it
+/// can never be raced by an unrelated, concurrent `cargo check`/`cargo build` (e.g.
+/// an IDE background build) overwriting the certs this test depends on mid-run.
+fn resolve_test_config_path() -> String {
+    let out_dir =
+        env::var("OUT_DIR").expect("OUT_DIR must be set by cargo for build-script crates");
+    let template =
+        fs::read_to_string(TEST_CONFIG_TEMPLATE).expect("failed to read TLS test config template");
+    let resolved = template.replace("tests/tls/", &format!("{out_dir}/"));
+    let resolved_path = format!("{out_dir}/tls-test-config.yaml");
+    fs::write(&resolved_path, resolved).expect("failed to write resolved TLS test config");
+    resolved_path
+}
 
 fn prepare_test_cases() -> Vec<TestConfig> {
     vec![
@@ -49,7 +67,8 @@ fn prepare_test_cases() -> Vec<TestConfig> {
 async fn custom_tls_config() {
     init_logging();
 
-    let result = run_test_with_config(TEST_CONFIG_PATH, TEST_PORT, 60, true, async {
+    let config_path = resolve_test_config_path();
+    let result = run_test_with_config(&config_path, TEST_PORT, 60, true, async {
         let client = reqwest::Client::new();
         let tasks: Vec<_> = prepare_test_cases()
             .into_iter()


### PR DESCRIPTION
## Add AWS SigV4 request signing for targets

Adds an optional per-target `aws_sigv4` config option that signs outgoing target requests with AWS Signature Version 4 — for hitting S3, API Gateway, OpenSearch, or any other SigV4-protected AWS endpoint directly from a listener.

### What's included

- **`aws_sigv4` target config**: `service` (required), `region` (optional, falls back to SDK default), `role_arn` (optional, assumes an IAM role via STS instead of using default credentials).
- **Credential resolution**: SDK-default only (env vars, `~/.aws/*`, IMDS, SSO, etc.) — no explicit access key config is supported by design.
- **Lazy AWS SDK init**: the SDK is only initialized if at least one target configures `aws_sigv4`.
- **Shared, half-life-refreshing credential cache**: one provider for default credentials plus one per unique `role_arn`, single-flighted to avoid a credentials/STS request storm, refreshed proactively at 50% of the credential validity window, falling back to stale credentials if a refresh fails.
- **Error routing**: signing failures produce a `SigningError` result routed through the existing `on_error` (`propagate`/`status`/`drop`) machinery, same as other target failures.
- Bumps crate version to `0.5.0`.

### Testing

- Unit tests for config parsing/validation, the credential cache (cache-until-half-life, single-flight, stale-on-refresh-failure, hard-expiry), and the signer (self-verified against independently computed SigV4 signatures, including session-token handling).
- New `tests/aws_sigv4.rs` end-to-end integration test against a localstack S3 container, covering both default-credential and assumed-role signing paths.

### Also included: test infra fix

Fixed a pre-existing race in `tests/scripts/create-test-certificates.sh` (invoked from `build.rs`): concurrent invocations (e.g. an IDE background build racing a terminal `cargo test`) could interleave writes to the shared `tests/tls/` cert path, leaving it empty or with a mismatched CA/server-cert pair and causing flaky TLS test failures.